### PR TITLE
Environment scripts to install @JSC (JUWELS & JURECA)

### DIFF
--- a/systems/jureca-gpu.sh
+++ b/systems/jureca-gpu.sh
@@ -1,0 +1,44 @@
+### environment ###
+
+# set up environment for building on the gpu part of jureca
+
+module use /usr/local/software/jureca/OtherStages/
+module load Stages/Devel-2018b
+
+module load CMake/3.13.0
+
+module load GCC/7.3.0 
+module load CUDA/9.2.88 
+module load MVAPICH2/2.3-GDR
+
+module load Python/3.6.6
+ns_python=$(which python3)
+
+# modules for (core)neuron
+module load mpi4py/3.0.0-Python-3.6.6
+module load flex/2.6.4
+module load Bison/.3.1
+
+### compilation options ###
+
+ns_cc=$(which mpicc)
+ns_cxx=$(which mpicxx)
+ns_with_mpi=ON
+
+ns_arb_with_gpu=ON
+ns_arb_arch=haswell
+
+ns_makej=20
+
+### benchmark execution options ###
+
+ns_threads_per_core=2
+ns_cores_per_socket=12
+ns_sockets=2
+ns_threads_per_socket=24
+
+# activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
+run_with_mpi() {
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket $*
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket $*
+}

--- a/systems/jureca-mc.sh
+++ b/systems/jureca-mc.sh
@@ -1,0 +1,39 @@
+### environment ###
+
+# set up environment for building on the multicore part of jureca
+
+module load CMake/3.13.0
+
+module load Python/3.6.6
+ns_python=$(which python3)
+
+# load before mpi4py because required
+module load GCC/8.2.0 ParaStationMPI/5.2.1-1
+
+# for (core)neuron
+module load mpi4py/3.0.0-Python-3.6.6
+module load flex/2.6.4
+module load Bison/.3.1
+
+### compilation options ###
+
+ns_cc=$(which mpicc)
+ns_cxx=$(which mpicxx)
+ns_with_mpi=ON
+
+ns_arb_arch=haswell
+
+ns_makej=20
+
+### benchmark execution options ###
+
+ns_threads_per_core=2
+ns_cores_per_socket=12
+ns_sockets=2
+ns_threads_per_socket=24
+
+# activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
+run_with_mpi() {
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+}

--- a/systems/juwels-mc.sh
+++ b/systems/juwels-mc.sh
@@ -1,0 +1,37 @@
+### environment ###
+
+# set up environment for building on the multicore part of juwels
+
+module load CMake/3.13.0
+
+module load Python/3.6.6
+ns_python=$(which python3)
+
+module load GCC/8.2.0 ParaStationMPI/5.2.1-1
+
+# for (core)neuron
+module load mpi4py/3.0.0-Python-3.6.6
+module load flex/2.6.4
+module load Bison/.3.1
+
+### compilation options ###
+
+ns_cc=$(which mpicc)
+ns_cxx=$(which mpicxx)
+ns_with_mpi=ON
+
+ns_arb_arch=skylake
+
+ns_makej=20
+
+### benchmark execution options ###
+
+ns_threads_per_core=2
+ns_cores_per_socket=24
+ns_sockets=2
+ns_threads_per_socket=48
+
+# activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
+run_with_mpi() {
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*

--- a/systems/juwels-mc.sh
+++ b/systems/juwels-mc.sh
@@ -35,3 +35,4 @@ ns_threads_per_socket=48
 run_with_mpi() {
     echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
     ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+}

--- a/systems/juwels-mc.sh
+++ b/systems/juwels-mc.sh
@@ -20,7 +20,7 @@ ns_cc=$(which mpicc)
 ns_cxx=$(which mpicxx)
 ns_with_mpi=ON
 
-ns_arb_arch=skylake
+ns_arb_arch=skylake-avx512
 
 ns_makej=20
 


### PR DESCRIPTION
Added scripts to set up environment at JSC`s JUWELS (mc) and JURECA (mc and gpu) for installing Arbor. 

Open: 
* juwels-gpu.sh, since CUDA9 driver not setup correctly in Devel-2018b Stage (in combination with GCC7)