### PR TITLE
Don't build examples when installing arbor

### DIFF
--- a/scripts/build_arbor.sh
+++ b/scripts/build_arbor.sh
@@ -44,7 +44,7 @@ cmake "$arb_repo_path" $cmake_args &>> "$out"
 cd "$arb_build_path"
 
 msg "ARBOR: build"
-make -j $ns_makej examples &>> "$out"
+make -j $ns_makej &>> "$out"
 [ $? != 0 ] && exit_on_error "see ${out}"
 
 msg "ARBOR: install"


### PR DESCRIPTION
Stop the Arbor build script from building the `examples` target, which is no longer needed because we no longer use the ring benchmark from the arbor examples.

Fixes #29