### PR TITLE
Benchmark runs produce standardised CSV output.

### DIFF
--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -134,7 +134,7 @@ private:
     double min_delay_;
     ring_params params_;
 
-    float event_weight_ = 0.05;
+    float event_weight_ = 0.01;
 };
 
 struct cell_stats {

--- a/benchmarks/engines/busyring/generate_inputs.py
+++ b/benchmarks/engines/busyring/generate_inputs.py
@@ -66,9 +66,13 @@ cnr_run_fid.write('source "%s/bench_output.sh"\n'%(scriptdir))
 arb_run_fid.write('odir="%s/arbor"\n'%(odir))
 nrn_run_fid.write('odir="%s/neuron"\n'%(odir))
 cnr_run_fid.write('odir="%s/coreneuron"\n'%(odir))
+# make output paths if they don't exist, and clean them.
 arb_run_fid.write('mkdir -p "$odir"\n')
 nrn_run_fid.write('mkdir -p "$odir"\n')
 cnr_run_fid.write('mkdir -p "$odir"\n')
+arb_run_fid.write('rm -f "$odir/*"\n')
+nrn_run_fid.write('rm -f "$odir/*"\n')
+cnr_run_fid.write('rm -f "$odir/*"\n')
 
 # quit early if required simulation engine is not in path
 arb_run_fid.write('[[ ! $(type -P arbor-busyring) ]]  && echo "Arbor needs to be installed before running benchmark"      && exit\n')
@@ -132,6 +136,10 @@ for ncells in cell_range:
 nrn_run_fid.write('echo\n')
 cnr_run_fid.write('echo\n')
 arb_run_fid.write('echo\n')
+
+arb_run_fid.write('%s/csv_bench.sh --path="$odir"\n'%(scriptdir))
+nrn_run_fid.write('%s/csv_bench.sh --path="$odir"\n'%(scriptdir))
+cnr_run_fid.write('%s/csv_bench.sh --path="$odir" --coreneuron\n'%(scriptdir))
 
 nrn_run_fid.close()
 arb_run_fid.close()

--- a/benchmarks/engines/busyring/neuron/run.py
+++ b/benchmarks/engines/busyring/neuron/run.py
@@ -146,7 +146,7 @@ meter.checkpoint('model-run')
 
 meter.print()
 
-prefix = env.opath+'/nrn_'+params.name+'_';
+prefix = env.opath+'/'+params.name+'_';
 
 report = metering.report_from_meter(meter)
 report.to_file(prefix+'meters.json')

--- a/common/python/neuron_tools.py
+++ b/common/python/neuron_tools.py
@@ -24,11 +24,11 @@ def hoc_setup():
 class neuron_context:
     def __repr__(self):
         s = "-- neuron context ----------------------------\n" \
-            "{0:20s}{1:>20d}\n" \
-            "{2:20s}{3:>20d}\n" \
-            "{4:20s}{5:>20d}\n" \
+            "{0:12s}    no\n" \
+            "{1:12s}{2:>6d}\n" \
+            "{3:12s}{4:>6d}\n" \
             "----------------------------------------------\n"\
-            .format("threads", self.env.nthreads, "ranks", self.size, "rank", self.rank, "is_root", self.is_root)
+            .format("gpu:", "threads:", self.env.nthreads, "ranks:", self.size)
 
         return s
 

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -1,0 +1,25 @@
+.. _benchmarks:
+
+Benchmarks
+==================
+
+For a given model and simulation engine, and benchmark is run with a "parameter sweep", for
+example it is run multiple times with increasing number of cells, to understand scaling.
+
+Benchmark output
+----------------
+
+Results form a benchmark sweep are stored in a simple file format
+
+CSV example:
+
+.. code-block::
+
+    cells, compartments, time, memory, energy, name
+    2,     128,          2.3,   10.7,  2.05,   ring_2
+    3,     270,          4.7,   20.1,  4.1,    ring_4
+
+JSON:
+
+.. code-block::
+

--- a/scripts/csv_bench.sh
+++ b/scripts/csv_bench.sh
@@ -1,0 +1,117 @@
+usage() {
+    cat <<_end_
+Usage: csv-bench.sh --path=PATH [--coreneuron]
+
+Generate CSV file summarising a set of benchmark runs.
+
+Options:
+    --path=PATH      Path containing the output
+    --coreneuron     If the path contains CoreNeuron output.
+_end_
+    exit 1
+}
+
+parse_coreneuron=false
+path=
+
+while [ "$1" != "" ]
+do
+    case $1 in
+        --coreneuron )
+            parse_coreneuron=true
+            ;;
+        --path=* )
+            path="${1#--path=}"
+            ;;
+        --path )
+            shift
+            path=$1
+            ;;
+        * )
+            echo "unknown option '$1'"
+            usage
+    esac
+    shift
+done
+
+if [ "$path" == "" ]
+then
+    usage
+    exit 1
+fi
+
+if [ ! -d "$path" ]
+then
+    echo "error: path \"$path\" does not exist"
+    exit 1
+fi
+
+table_line() {
+    fid="$1"
+    line=
+
+    tts=`awk '/^model-run/ {print $2}' "$fid"`
+    ncell=`awk '/^cell stats/ {print $3}' "$fid"`
+
+    line="$(printf "%9d,%12.3f," $ncell $tts)"
+    nranks=`awk '/^ranks:/ {print $2}' "$fid"`
+
+    mempos=`awk '/^meter / {j=-1; for(i=1; i<=NF; ++i) if($i =="memory(MB)") j=i; print j}' "$fid"`
+    if [ "$mempos" != "-1" ]
+    then
+        rankmem=$(awk "/^meter-total/ {print \$$mempos}" "$fid")
+        totalmem=`echo $rankmem*$nranks | bc -l`
+        line="$line$(printf "%12.3f," $totalmem)"
+    else
+        line="$line$(printf "%12s," "")"
+    fi
+
+    nthreads=`awk '/^threads:/ {print $2}' "$fid"`
+    hasgpu=`awk '/^gpu:/ {print $2}' "$fid"`
+    line="$line$(printf "%7d,%7d,%7s" $nranks $nthreads $hasgpu)"
+}
+
+# NOTE: this is very fragile and will almost certainly break from version to
+# version of CoreNeuron. There is not much we can do about that, because the
+# only information we have available is whatever CoreNeuron outputs to stdout.
+table_line_cnr() {
+    fid="$1"
+    line=
+
+    tts=`grep "Solver Time" "$fid" | awk '{print $4}'`
+    ncell=`grep "Number of cells" "$fid" | awk '{print $4}'`
+
+    rankmem_start=`grep "After MPI_Init" "$fid" | awk '{print $12}'`
+    rankmem_end=`grep "After nrn_finitialize" "$fid" | awk '{print $12}'`
+    rankmem=`echo $rankmem_end-$rankmem_start | bc -l`
+    # num_mpi and num_omp_thread are printed more than once (for redundancy?)
+    # So use awk to discard all but the last occurence of each variable
+    nranks=`awk '/num_mpi/ {split($1,line,"="); x=line[2]} END{print x}' "$fid"`
+    nthreads=`awk '/num_omp_thread/ {split($1,line,"="); x=line[2]} END{print x}' "$fid"`
+    totalmem=`echo $rankmem*$nranks | bc -l`
+    hasgpu="no" # we can't run CoreNeuron with GPU for now, so always no.
+
+    line="$line$(printf "%9d,%12.3f,%12.3f,%7d,%7d,%7s" $ncell $tts $totalmem $nranks $nthreads $hasgpu)"
+}
+
+files=$(ls "$path"/*.out)
+
+# Use tmp file to generate unsorted table.
+tmp="$path/tmp"
+results="$path/results.csv"
+rm -f "$tmp"
+for f in $files
+do
+    [[ "$parse_coreneuron" == "false" ]] && table_line $f
+    [[ "$parse_coreneuron" == "true" ]]  && table_line_cnr $f
+    echo "$line" >> "$tmp"
+done
+printf "%9s,%12s,%12s,%7s,%7s,%7s\n" \
+       "cells" "wall time(s)" "memory (MB)" "ranks" "threads" "gpu" \
+       > "$results"
+
+# Sorting in ascending order of the number of cells (the first column in the output).
+# The output does not have to be sorted; however sorting by the number of cells will usuall
+# match the natural order of scaling benchmarks.
+sort -n "$tmp" >> "$results"
+rm -f "$tmp"

--- a/scripts/csv_bench.sh
+++ b/scripts/csv_bench.sh
@@ -53,7 +53,7 @@ table_line() {
     tts=$(awk '/^model-run/ {print $2}' "$fid")
     ncell=$(awk '/^cell stats/ {print $3}' "$fid")
 
-    line=$(printf "%9d,%12.3f," $ncell $tts)
+    line=$(printf %9d,%12.3f, $ncell $tts)
     nranks=$(awk '/^ranks:/ {print $2}' "$fid")
 
     mempos=$(awk '/^meter / {j=-1; for(i=1; i<=NF; ++i) if($i =="memory(MB)") j=i; print j}' "$fid")
@@ -61,14 +61,14 @@ table_line() {
     then
         rankmem=$(awk "/^meter-total/ {print \$$mempos}" "$fid")
         totalmem=$(echo $rankmem*$nranks | bc -l)
-        line="$line$(printf "%12.3f," $totalmem)"
+        line="$line"$(printf %12.3f, $totalmem)
     else
-        line="$line$(printf "%12s," "")"
+        line="$line"$(printf %12s, '')
     fi
 
     nthreads=$(awk '/^threads:/ {print $2}' "$fid")
     hasgpu=$(awk '/^gpu:/ {print $2}' "$fid")
-    line="$line$(printf "%7d,%7d,%7s" $nranks $nthreads $hasgpu)"
+    line="$line"$(printf %7d,%7d,%7s $nranks $nthreads $hasgpu)
 }
 
 # NOTE: this is very fragile and will almost certainly break from version to
@@ -91,7 +91,7 @@ table_line_cnr() {
     # we can't run CoreNeuron with GPU for now, so always no.
     hasgpu="no"
 
-    line=$(printf "%9d,%12.3f,%12.3f,%7d,%7d,%7s" $ncell $tts $totalmem $nranks $nthreads $hasgpu)
+    line=$(printf %9d,%12.3f,%12.3f,%7d,%7d,%7s $ncell $tts $totalmem $nranks $nthreads $hasgpu)
 }
 
 # Use tmp file to generate unsorted table.
@@ -104,7 +104,7 @@ do
     [[ "$parse_coreneuron" == "true" ]]  && table_line_cnr $f
     echo "$line" >> "$tmp"
 done
-printf "%9s,%12s,%12s,%7s,%7s,%7s\n" \
+printf %9s,%12s,%12s,%7s,%7s,%7s\n \
        "cells" "wall time(s)" "memory (MB)" "ranks" "threads" "gpu" \
        > "$results"
 


### PR DESCRIPTION
* New script scripts/csv_bench.sh generates csv file
  that summarises key benchmark results (wall time, memory, cells, etc)
  for all benchmark runs in a path
* Benchmark runners call this script after running each benchmark
  case.
* Fix Arbor busyring to use the same connection weight as Neuron.