### PR TITLE
Rejig Findnetcdf.cmake

### DIFF
--- a/systems/juwels-mc.sh
+++ b/systems/juwels-mc.sh
@@ -14,6 +14,9 @@ module load mpi4py/3.0.0-Python-3.6.6
 module load flex/2.6.4
 module load Bison/.3.1
 
+# for validation tests
+module load netCDF
+
 ### compilation options ###
 
 ns_cc=$(which mpicc)

--- a/validation/src/arbor-rc-exp2syn-spike/CMakeLists.txt
+++ b/validation/src/arbor-rc-exp2syn-spike/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.9)
 project(arbor-rc-exp2syn-spike LANGUAGES CXX)
 
-find_package(arbor REQUIRED)
-
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+include(UseLibraryPath)
+
+find_package(arbor REQUIRED)
 find_package(netcdf REQUIRED)
 
 add_executable(arbor-rc-exp2syn-spike arbor-rc-exp2syn-spike.cpp)
-target_link_libraries(arbor-rc-exp2syn-spike arbor::arbor PkgConfig::netcdf)
+target_link_libraries(arbor-rc-exp2syn-spike arbor::arbor netcdf::netcdf)
 
 install(TARGETS arbor-rc-exp2syn-spike DESTINATION bin)
 

--- a/validation/src/arbor-rc-expsyn/CMakeLists.txt
+++ b/validation/src/arbor-rc-expsyn/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.9)
 project(arbor-rc-expsyn LANGUAGES CXX)
 
-find_package(arbor REQUIRED)
-
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+include(UseLibraryPath)
+
+find_package(arbor REQUIRED)
 find_package(netcdf REQUIRED)
 
 add_executable(arbor-rc-expsyn arbor-rc-expsyn.cpp)
-target_link_libraries(arbor-rc-expsyn arbor::arbor PkgConfig::netcdf)
+target_link_libraries(arbor-rc-expsyn arbor::arbor netcdf::netcdf)
 
 install(TARGETS arbor-rc-expsyn DESTINATION bin)
 

--- a/validation/src/cmake/Findnetcdf.cmake
+++ b/validation/src/cmake/Findnetcdf.cmake
@@ -1,7 +1,29 @@
+# Wrap FindPkgConfig to make an NetCDF interface target netcdf::netcdf.
+
 find_package(PkgConfig REQUIRED)
 
 foreach(dir "$ENV{NETCDF_DIR}" "$ENV{HDF5_DIR}")
     set(ENV{PKG_CONFIG_PATH} "${dir}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 endforeach()
 
-pkg_check_modules(netcdf REQUIRED IMPORTED_TARGET netcdf)
+pkg_check_modules(netcdf netcdf)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(netcdf
+  FOUND_VAR netcdf_FOUND
+  REQUIRED_VARS netcdf_LDFLAGS
+  VERSION_VAR netcdf_VERSION
+)
+
+if(netcdf_FOUND AND NOT TARGET netcdf::netcdf)
+    # Create interface library directly from recorded pkgconfig output
+    # to help avoid issues with 1) FindPkgConfig's use of find_library
+    # and 2) the 'GLOBAL' flag only being a very recent addition to
+    # pkg_check_modules().
+
+    add_library(netcdf::netcdf INTERFACE IMPORTED GLOBAL)
+    target_link_libraries(netcdf::netcdf INTERFACE ${netcdf_LDFLAGS})
+    target_include_directories(netcdf::netcdf INTERFACE ${netcdf_INCLUDE_DIRS})
+    target_compile_options(netcdf::netcdf INTERFACE ${netcdf_CFLAGS_OTHER})
+endif()
+

--- a/validation/src/cmake/UseLibraryPath.cmake
+++ b/validation/src/cmake/UseLibraryPath.cmake
@@ -1,0 +1,6 @@
+# Append LIBRARY_PATH environment variable paths to CMAKE_LIBRARY_PATH
+# so that find_library() will Do The Right Thing.
+
+file(TO_CMAKE_PATH "$ENV{LIBRARY_PATH}" env_lib_path_)
+list(APPEND CMAKE_LIBRARY_PATH ${env_lib_path_})
+


### PR DESCRIPTION
Fixes validation build failure on Juwels.

* More involved wrapping of CMake FindPkgConfig module for NetCDF discovery, including the use of `LIBRARY_PATH` which apparently CMake does not bother to look in by default when performing `find_library()` searches.
* Add netcdf module load to juwels-mc environment script.