### PR TITLE
Fix non-POSIX usage of awk, date.

### DIFF
--- a/common/bin/pathsub
+++ b/common/bin/pathsub
@@ -48,7 +48,7 @@ done
 strings+=("${@}")
 
 function subformat {
-    awk -e \
+    awk \
        'BEGIN {
            lookup["%%"] = "%"
            maxkeylen = 2

--- a/install-local.sh
+++ b/install-local.sh
@@ -138,7 +138,10 @@ mkdir -p "$ns_build_path"
 # Record system configuration name, timestamp.
 # (This data will also be recorded in constructed environments.)
 
-ns_timestamp=$(date -Isec)
+# Note: format (and sed processing) chosen to match RFC 3339 profile
+# for ISO 8601 date formatting, matching GNU date -Isec output.
+ns_timestamp=$(date +%Y-%m-%ST%H:%M:%S%z | sed 's/[0-9][0-9]$/:&/')
+
 echo "$ns_timestamp" > "$ns_build_path/timestamp"
 echo "${ns_sysname:=$(hostname -s)}" > "$ns_build_path/sysname"
 


### PR DESCRIPTION
* Remove `-e` option from awk invocation.
* Substitute `-Isec` option on `date` with explicit formatting.

Fixes #45.