### PR TITLE
CoreNEURON implementation for rc-exp2syn-spike

### DIFF
--- a/run-validation.sh
+++ b/run-validation.sh
@@ -12,7 +12,6 @@ Options:
     -r, --refresh              Regenerate any cached reference data.
     -m, --model=MODEL/[PARAM]  Run given model/parameter test.
 
-SIMULATOR is one of: arbor, neuron
 If no model is explicitly provided, all available tests will be run.
 
 The output FORMAT is a pattern that is used to determine the output
@@ -105,14 +104,12 @@ while [ -n "$1" ]; do
         -r | --refresh )
             ns_refresh_cache="-r"
             ;;
-        neuron )
-            sims="$sims neuron"
-            ;;
-        arbor )
-            sims="$sims arbor"
+        -* | --* )
+            argerror "unknown option '$1'"
             ;;
         * )
-            argerror "unknown option '$1'"
+            sims="$sims $1"
+            ;;
     esac
     shift
 done

--- a/scripts/build_coreneuron.sh
+++ b/scripts/build_coreneuron.sh
@@ -55,5 +55,7 @@ make install >> "$out" 2>&1
 
 cd $ns_base_path
 
+coreneuronlib=$(find "$ns_install_path" -name libcoreneuron.so -print -quit)
+
 msg "CoreNeuron: saving environment"
-save_environment coreneuron
+save_environment coreneuron "export CORENEURONLIB='$coreneuronlib'"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -135,10 +135,13 @@ find_installed_paths() {
 # installation-time information, viz. ns_timestamp and
 # ns_sysname.
 # 
-# Takes one argument: name of the simulation engine, one of: {arb, nrn, corenrn}
+# Take name of simulation engine (one of: {arb, nrn, corenrn}) as
+# first argument; any additional arguments are appended to the
+# generated config script verbatim.
 save_environment() {
     set_working_paths
     sim="$1"
+    shift
 
     # Find and record python, bin, and lib paths.
     python_path=$(find_installed_paths site-packages)"$ns_base_path/common/python:"
@@ -165,4 +168,9 @@ source "$ns_base_path/scripts/environment.sh"
 default_environment
 $source_env_script
 _end_
+
+    for appendix in "${@}"; do
+        echo "$appendix" >> "$ns_config_path/env_$sim.sh"
+    done
 }
+

--- a/scripts/model_common.sh
+++ b/scripts/model_common.sh
@@ -83,3 +83,27 @@ function model_notify_pass_fail {
     fi
 }
 
+# Attempt to run given simulator-specific script, redirecting
+# stdout and stderr to files in $model_output_dir.
+#
+# Report if error or if implementation is missing.
+
+function model_try_run {
+    local light_red=$'\033[1;31m'
+    local magenta=$'\033[1;35m'
+    local nc=$'\033[0m'
+
+    impl="$1"
+    shift
+
+    if [ ! -x "./$impl" ]; then
+        echo "${magenta}[UNIMPLEMENTED]${nc} $model_sim $model_name/$model_param"
+        exit 0
+    fi
+
+    "./$impl" "${@}" > "$model_output_dir/run.out" 2> "$model_output_dir/run.err" || {\
+        echo "${light_red}[ERROR]${nc} $model_sim $model_name/$model_param"
+        exit 0
+    }
+}
+

--- a/validation/rc-exp2syn-spike/neuron-rc-exp2syn-spike.py
+++ b/validation/rc-exp2syn-spike/neuron-rc-exp2syn-spike.py
@@ -146,6 +146,16 @@ else:
     pc.set_maxstep(mindelay)
     h.finitialize()
 
+    # CoreNEURON output is always in the form of a file
+    # 'out.dat' in the current working directory containing
+    # spike data. We temporarily move to a temporary directory
+    # to call `pc.nrncore_run` so as not to scribble over
+    # the current directory.
+    #
+    # The spike data is formatted with one record per line,
+    # two fields per record delimitted by tab: time (ms) and
+    # gid.
+
     cwd = os.getcwd()
     with tempfile.TemporaryDirectory() as tmpdir:
         os.chdir(tmpdir)

--- a/validation/rc-exp2syn-spike/run
+++ b/validation/rc-exp2syn-spike/run
@@ -18,8 +18,9 @@ model_setup rc-exp2syn-spike "$@"
 # For CoreNEURON, voltage traces will be omitted; the pass/fail
 # test only looks at spike time differences.
 
+# Run sim-specific implementation with parameter data.
 outfile="$model_output_dir/run.nc"
-./"run-$model_sim" "$outfile" $model_param_data
+model_try_run "run-$model_sim" "$outfile" $model_param_data
 
 # Generate reference data if required.
 reffile=$(model_find_cacheable "ref-${model_name}-${model_param}.nc")

--- a/validation/rc-exp2syn-spike/run-coreneuron
+++ b/validation/rc-exp2syn-spike/run-coreneuron
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+./neuron-rc-exp2syn-spike.py "${@}" coreneuron=1

--- a/validation/rc-expsyn/run
+++ b/validation/rc-expsyn/run
@@ -9,9 +9,9 @@ cd "${BASH_SOURCE[0]%/*}"
 source "$ns_base_path/scripts/model_common.sh"
 model_setup rc-expsyn "$@"
 
-# Run sim-specific model with parameter data.
+# Run sim-specific implementation with parameter data.
 outfile="$model_output_dir/run.nc"
-./"run-$model_sim" "$outfile" $model_param_data
+model_try_run "run-$model_sim" "$outfile" $model_param_data
 
 # Generate reference data if required.
 reffile=$(model_find_cacheable "ref-${model_name}-${model_param}.nc")


### PR DESCRIPTION
Implements #14.

* Modify `neuron-rc-exp2syn-spike.py` to accept an additional 'coreneuron=' parameter; build model for CoreNEURON and execute it with `nrncore_run`.
* Extend save_environment function in environment.sh to allow extra arguments to be suffixed to the generated config script.
* Add `CORENEURONLIB` export in generated env_coreneuron.sh.
* Let run-validation.sh be less picky about simulator names.
* Add `model_try_run` utility function that reports errors with validation model implementations and saves stdout/stderr to files int the output directory.