### PR TITLE
Add python virtualenv to manage py modules.

### DIFF
--- a/install-local.sh
+++ b/install-local.sh
@@ -1,23 +1,32 @@
 usage() {
     cat <<'_end_'
-Usage: install-local.sh [--env=SCRIPT] [--prefix=PATH] TARGET [TARGET...]
+Usage: install-local.sh [--pyvenv=VENVOPT] [--env=SCRIPT] [--prefix=PATH] TARGET [TARGET...]
 
 Setup NSuite framework, build and install simulators, benchmarks,
 and validation tests.
 
 Options:
-    --env=SCRIPT       Source SCRIPT before building.
-    --prefix=PATH   Use PATH as base for install and other run-time
-                    working directories.
+    --pyvenv=VENVOPT  Customize use of Python virtual environment (see below)
+    --env=SCRIPT      Source SCRIPT before building.
+    --prefix=PATH     Use PATH as base for install and other run-time
+                      working directories.
 
 TARGET is one of:
-   arbor            Build Arbor.
-   neuron           Build NEURON.
-   coreneuron       Build CoreNEURON.
-   all              Build all simulators.
+    arbor             Build Arbor.
+    neuron            Build NEURON.
+    coreneuron        Build CoreNEURON.
+    all               Build all simulators.
 
 Building a TARGET will also build any associated tests and
 benchmarks as required.
+
+By default, a Python virtual environment is created in which required modules
+are installed if they are missing in the system environment.
+VENVOPT is one of:
+    disable           Do not use a Python virtualenv at all.
+    inherit           Use a virtualenv, using site packages.
+    enable            Use a virtualenv, ignoring site packages (default).
+
 _end_
 }
 
@@ -34,6 +43,7 @@ ns_build_nest=false
 ns_build_neuron=false
 ns_build_coreneuron=false
 ns_environment=
+ns_pyvenv=enable
 
 while [ "$1" != "" ]
 do
@@ -52,6 +62,13 @@ do
             ns_build_neuron=true
             ns_build_coreneuron=true
             ;;
+        --pyvenv=* )
+            ns_pyvenv=${1#--pyvenv=}
+	    ;;
+        --pyvenv )
+	    shift
+            ns_pyvenv=$1
+	    ;;
         --env=* )
             ns_environment=${1#--env=}
             ;;
@@ -73,6 +90,12 @@ do
     esac
     shift
 done
+
+if [ "$ns_pyvenv" != disable -a "$ns_pyvenv" != enable -a "$ns_pyvenv" != inherit ]; then
+    echo "unrecognized argument for --pyvenv: '$ns_pyvenv'"
+    usage
+    exit 1
+fi
 
 # Load utility functions and set up default environment.
 
@@ -143,6 +166,28 @@ mkdir -p "$ns_build_path"
 ns_timestamp=$(date +%Y-%m-%ST%H:%M:%S%z | sed 's/[0-9][0-9]$/:&/')
 echo "$ns_timestamp" > "$ns_build_path/timestamp"
 echo "${ns_sysname:=$(hostname -s)}" > "$ns_build_path/sysname"
+
+# Set up python virtual environment.
+
+if [ "$ns_pyvenv" != disable ]; then
+    echo
+    msg "Initializing python virtual environment"
+    ns_pyvenv_opt=
+    if [ "$ns_pyvenv" == inherit ]; then
+	ns_pyvenv_opt=--system-site-packages
+    fi
+
+    msg "Installing python modules: $ns_pyvenv_modules"
+    (
+	exec >> "$ns_build_path/log_pyvenv" 2>&1
+	if python3 -m venv $ns_pyvenv_opt "$ns_pyvenv_path"; then
+	    source "$ns_pyvenv_path/bin/activate"
+	    for pkg in $ns_pyvenv_modules; do
+	        pip install "$pkg"
+	    done
+	fi
+    )
+fi
 
 # Build simulator targets.
 

--- a/install-local.sh
+++ b/install-local.sh
@@ -180,7 +180,7 @@ if [ "$ns_pyvenv" != disable ]; then
     msg "Installing python modules: $ns_pyvenv_modules"
     (
 	exec >> "$ns_build_path/log_pyvenv" 2>&1
-	if python3 -m venv $ns_pyvenv_opt "$ns_pyvenv_path"; then
+	if "$ns_python" -m venv $ns_pyvenv_opt "$ns_pyvenv_path"; then
 	    source "$ns_pyvenv_path/bin/activate"
 	    for pkg in $ns_pyvenv_modules; do
 	        pip install "$pkg"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -15,6 +15,8 @@ set_working_paths() {
     export ns_bench_input_path="$ns_prefix/input/benchmarks"
     export ns_bench_output="$ns_prefix/output/benchmark"
     export ns_validation_output="$ns_prefix/output/validation"
+
+    export ns_pyvenv_path="$ns_build_path/pyvenv"
 }
 
 # Sets up the default enviroment.
@@ -58,6 +60,9 @@ default_environment() {
     ns_python=
     command -v python3 &> /dev/null
     [ $? = 0 ] && ns_python=$(which python3)
+
+    # Python venv module list
+    ns_pyvenv_modules="scipy xarray"
 
     # Arbor specific
 
@@ -156,6 +161,12 @@ save_environment() {
         source_env_script='source '$(full_path "$ns_environment")
     fi
 
+    pyvenv_activate=$ns_pyvenv_path/bin/activate
+    source_pyvenv_script=
+    if [ -r "$pyvenv_activate" ]; then
+	source_pyvenv_script="source '$pyvenv_activate'"
+    fi
+
     cat <<_end_ > "$ns_config_path/env_$sim.sh"
 export ns_prefix="$ns_prefix"
 export ns_timestamp="$ns_timestamp"
@@ -167,6 +178,7 @@ export LD_LIBRARY_PATH="${lib_path}:\$LD_LIBRARY_PATH"
 source "$ns_base_path/scripts/environment.sh"
 default_environment
 $source_env_script
+$source_pyvenv_script
 _end_
 
     for appendix in "${@}"; do

--- a/systems/daint-gpu.sh
+++ b/systems/daint-gpu.sh
@@ -9,17 +9,18 @@ ns_sysname="daint-gpu"
 module load daint-gpu
 module load CMake
 
-module load cray-python/3.6.5.1
-ns_python=python3
+module load cudatoolkit/9.2.148_3.19-6.0.7.1_2.1__g3d9acc8
 module load cray-hdf5 cray-netcdf
 
-# PyExtensions is needed for cython, mpi4py and others.
-# It loads cray-python/3.6.5.1 which points python at version 3.6.1.1
-module load PyExtensions/3.6.5.1-CrayGNU-18.08
+module load cray-python/3.6.5.1
 ns_python=python3
 
-# load after python tools because easybuild...
+# load after python because easybuild...
 module swap gcc/6.2.0
+
+# add mpi4py to virtualenv build
+export MPICC="$(which cc)"
+ns_pyvenv_modules+=" Cython>=0.28 mpi4py>=3.0"
 
 ### compilation options ###
 

--- a/systems/daint-gpu.sh
+++ b/systems/daint-gpu.sh
@@ -9,13 +9,14 @@ ns_sysname="daint-gpu"
 module load daint-gpu
 module load CMake
 
-module load cudatoolkit/9.2.148_3.19-6.0.7.1_2.1__g3d9acc8
+module load cray-python/3.6.5.1
+ns_python=python3
 module load cray-hdf5 cray-netcdf
 
 # PyExtensions is needed for cython, mpi4py and others.
 # It loads cray-python/3.6.5.1 which points python at version 3.6.1.1
 module load PyExtensions/3.6.5.1-CrayGNU-18.08
-ns_python=$(which python3)
+ns_python=python3
 
 # load after python tools because easybuild...
 module swap gcc/6.2.0
@@ -41,6 +42,6 @@ ns_sockets=1
 ns_threads_per_socket=24
 
 run_with_mpi() {
-    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket $*
-    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket $*
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket "${@}"
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket "${@}"
 }

--- a/systems/daint-mc.sh
+++ b/systems/daint-mc.sh
@@ -11,13 +11,15 @@ module load CMake
 
 module load cray-hdf5 cray-netcdf
 
-# PyExtensions is needed for cython, mpi4py and others.
-# It loads cray-python/3.6.5.1
-module load PyExtensions/3.6.5.1-CrayGNU-18.08
-ns_python=$(which python3)
+module load cray-python/3.6.5.1
+ns_python=python3
 
 # load after python tools because easybuild...
 module swap gcc/7.3.0
+
+# add mpi4py to virtualenv build
+export MPICC="$(which cc)"
+ns_pyvenv_modules+=" Cython>=0.28 mpi4py>=3.0"
 
 ### compilation options ###
 
@@ -39,6 +41,6 @@ ns_sockets=2
 ns_threads_per_socket=36
 
 run_with_mpi() {
-    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
-    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}"
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}" 
 }

--- a/systems/daint-mc.sh
+++ b/systems/daint-mc.sh
@@ -14,7 +14,7 @@ module load cray-hdf5 cray-netcdf
 module load cray-python/3.6.5.1
 ns_python=python3
 
-# load after python tools because easybuild...
+# load after python because easybuild...
 module swap gcc/7.3.0
 
 # add mpi4py to virtualenv build

--- a/systems/jureca-gpu.sh
+++ b/systems/jureca-gpu.sh
@@ -15,7 +15,7 @@ module load CUDA/9.2.88
 module load MVAPICH2/2.3-GDR
 
 module load Python/3.6.6
-ns_python=$(which python3)
+ns_python=python3
 
 # modules for (core)neuron
 module load mpi4py/3.0.0-Python-3.6.6
@@ -42,6 +42,6 @@ ns_threads_per_socket=24
 
 # activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
 run_with_mpi() {
-    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket $*
-    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket $*
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket "${@}" 
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -N $ns_sockets -c $ns_threads_per_socket "${@}" 
 }

--- a/systems/jureca-mc.sh
+++ b/systems/jureca-mc.sh
@@ -8,7 +8,7 @@ ns_sysname="jureca-mc"
 module load CMake/3.13.0
 
 module load Python/3.6.6
-ns_python=$(which python3)
+ns_python=python3
 
 # load before mpi4py because required
 module load GCC/8.2.0 ParaStationMPI/5.2.1-1
@@ -37,6 +37,6 @@ ns_threads_per_socket=24
 
 # activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
 run_with_mpi() {
-    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
-    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}" 
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}" 
 }

--- a/systems/juwels-mc.sh
+++ b/systems/juwels-mc.sh
@@ -8,7 +8,7 @@ ns_sysname="juwels-mc"
 module load CMake/3.13.0
 
 module load Python/3.6.6
-ns_python=$(which python3)
+ns_python=python3
 
 module load GCC/8.2.0 ParaStationMPI/5.2.1-1
 
@@ -39,6 +39,6 @@ ns_threads_per_socket=48
 
 # activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
 run_with_mpi() {
-    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
-    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}" 
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}" 
 }

--- a/systems/tave.sh
+++ b/systems/tave.sh
@@ -8,7 +8,7 @@ export PATH="/users/bcumming/cmake/cmake-3.13.0-rc1/bin:$PATH"
 # PyExtensions is needed for cython, mpi4py and others.
 # It loads cray-python/3.6.5.1
 module load cray-python/3.6.5.1
-ns_python=$(which python3)
+ns_python=python3
 
 # load after python tools because easybuild...
 module swap gcc/7.3.0
@@ -33,6 +33,6 @@ ns_sockets=1
 ns_threads_per_socket=64
 
 run_with_mpi() {
-    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
-    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}" 
+    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket "${@}" 
 }


### PR DESCRIPTION
Implements #13.

* Don't use absolute paths to python executables in ns_python assignments in system scripts, to allow correct use of virtualenv version.
* Add new ns_ variable ns_pyenv_modules that can be amended in system scripts for determining module set up in venv.
* Add scipy and xarray to default virtualenv module list.
* Add explicit mpi4py 3.0 to virtualenv module list for daint to help work around MPI link issue.
* Add virtualenv building in install-local.sh, together with command line flag for managing this.
* Quote arguments forwarded in run_with_mpi functions.