### PR TITLE
CoreNEURON with GPUs on Daint

### DIFF
--- a/benchmarks/engines/busyring/generate_inputs.py
+++ b/benchmarks/engines/busyring/generate_inputs.py
@@ -86,10 +86,10 @@ arb_run_fid.write('[[ ! $(type -P arbor-busyring) ]]  && echo "Arbor needs to be
 nrn_run_fid.write('[[ ! $(type -P nrniv) ]]           && echo "NEURON needs to be installed before running benchmark"     && exit\n')
 cnr_run_fid.write('[[ ! $(type -P coreneuron_exec) ]] && echo "CoreNeuron needs to be installed before running benchmark" && exit\n')
 
-# quit early if required simulation engine is not in path
-arb_run_fid.write('[[ ! $(type -P arbor-busyring) ]]  && echo "Arbor needs to be installed before running benchmark"      && exit\n')
-nrn_run_fid.write('[[ ! $(type -P nrniv) ]]           && echo "NEURON needs to be installed before running benchmark"     && exit\n')
-cnr_run_fid.write('[[ ! $(type -P coreneuron_exec) ]] && echo "CoreNeuron needs to be installed before running benchmark" && exit\n')
+# "flag" will be passed to coreneuron_exec
+cnr_run_fid.write('flag=\n')
+cnr_run_fid.write('[[ "$ns_cnrn_gpu" = "true" ]] && flag="$flag -gpu --cell-permute 2"\n')
+cnr_run_fid.write('[[ "$ns_with_mpi" = "ON" ]] && flag="$flag -mpi"\n')
 
 header='echo "  cells compartments    wall(s)  throughput  mem-tot(MB) mem-percell(MB)"\n'
 cnr_run_fid.write(header)
@@ -129,7 +129,7 @@ for ncells in cell_range:
     cnr_run_fid.write('corenrn_ofile="$odir/%s".out\n'%(run_name))
     cnrn_input_path=('%s/%s_core'%(idir, run_name))
     cnr_run_fid.write('if [ -d "%s" ]; then\n'%(cnrn_input_path))
-    cnr_run_fid.write('  run_with_mpi coreneuron_exec -mpi -d "%s" -e %s --outpath "$odir" &> "$corenrn_ofile"\n'%(cnrn_input_path, str(duration)))
+    cnr_run_fid.write('  run_with_mpi coreneuron_exec $flag -d "%s" -e %s --outpath "$odir" &> "$corenrn_ofile"\n'%(cnrn_input_path, str(duration)))
     cnr_run_fid.write('  coreneuron_table_line "$corenrn_ofile"\n')
     cnr_run_fid.write('  [ -f "$odir/out.dat" ] && mv "$odir/out.dat" "$odir/%s_spikes.dat"\n'%(run_name))
     cnr_run_fid.write('else\n')

--- a/benchmarks/engines/busyring/neuron/run.py
+++ b/benchmarks/engines/busyring/neuron/run.py
@@ -1,3 +1,5 @@
+import sys
+
 import config
 import random
 env = config.load_env()

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -147,12 +147,10 @@ fi
 # TODO: this has to go into the configuration environment setup scripts
 export ARB_NUM_THREADS=$[ $ns_threads_per_core * $ns_cores_per_socket ]
 
-msg "platform:          $ns_system"
-msg "cores per socket:  $ns_cores_per_socket"
-msg "threads per core:  $ns_threads_per_core"
-msg "threads:           $ARB_NUM_THREADS"
-msg "sockets:           $ns_sockets"
-msg "mpi:               $ns_with_mpi"
+msg "NSuite benchmark runner"
+echo
+msg "models:   $models"
+msg "configs:  $configs"
 echo
 
 mkdir -p "$ns_bench_input_path"

--- a/scripts/build_coreneuron.sh
+++ b/scripts/build_coreneuron.sh
@@ -37,12 +37,19 @@ mkdir -p "$cnrn_build_path"
 # configure the build with cmake
 cd "$cnrn_build_path"
 cmake_args=-DCMAKE_INSTALL_PREFIX:PATH="$ns_install_path"
-# turn off tests, because these cause linking problems with boost.
+# Turn off tests, because these cause linking problems with boost.
 cmake_args="$cmake_args -DUNIT_TESTS=off"
 cmake_args="$cmake_args -DFUNCTIONAL_TESTS=off"
 cmake_args="$cmake_args -DENABLE_MPI=$ns_with_mpi"
+if [ "$ns_cnrn_gpu" == "true" ]
+then
+    cmake_args="$cmake_args -DCOMPILE_LIBRARY_TYPE=STATIC -DCUDA_HOST_COMPILER=`which gcc` -DCUDA_PROPAGATE_HOST_FLAGS=OFF -DENABLE_SELECTIVE_GPU_PROFILING=ON -DENABLE_OPENACC=ON -DCORENEURON_OPENMP=OFF"
+else
+    cmake_args="$cmake_args -DENABLE_OPENACC=OFF -DCORENEURON_OPENMP=ON"
+fi
+
 msg "CoreNEURON: cmake $cmake_args"
-cmake "$cnrn_repo_path" $cmake_args >> "$out" 2>&1
+cmake "$cnrn_repo_path" $cmake_args -DCMAKE_C_FLAGS="$ns_cnrn_compiler_flags" -DCMAKE_CXX_FLAGS="$ns_cnrn_compiler_flags" >> "$out" 2>&1
 [ $? != 0 ] && exit_on_error "see ${out}"
 
 msg "CoreNEURON: make"

--- a/scripts/csv_bench.sh
+++ b/scripts/csv_bench.sh
@@ -80,13 +80,13 @@ table_line_cnr() {
     tts=$(awk '/Solver Time/ {print $4}' "$fid")
     ncell=$(awk '/Number of cells/ {print $4}' "$fid")
 
-    rankmem_start=$(awk '/After MPI_Init/ {print $12}' "$fid")
+    rankmem_start=$(awk '/Before nrn_setup/ {print $12}' "$fid")
     rankmem_end=$(awk '/After nrn_finitialize/ {print $12}' "$fid")
     rankmem=$(echo $rankmem_end-$rankmem_start | bc -l)
     # num_mpi and num_omp_thread are printed more than once (for redundancy?)
     # So use awk to discard all but the last occurence of each variable
-    nranks=$(awk -F= '/num_mpi/ {x=$2} END{print x}' "$fid")
-    nthreads=$(awk -F= '/num_omp_thread/ {x=$2} END{print x}' "$fid")
+    nranks=$(awk   -F= '/num_mpi/        {x=$2} END{print length(x)==0? 1: x;}' "$fid")
+    nthreads=$(awk -F= '/num_omp_thread/ {x=$2} END{print length(x)==0? 1: x;}' "$fid")
     totalmem=$(echo $rankmem*$nranks | bc -l)
     # we can't run CoreNeuron with GPU for now, so always no.
     hasgpu="no"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -89,6 +89,13 @@ default_environment() {
     # CoreNeuron specific
     ns_cnrn_git_repo=https://github.com/BlueBrain/CoreNeuron.git
     ns_cnrn_sha=0.14
+
+    # CoreNeuron can optionally target GPUs using PGI OpenACC.
+    ns_cnrn_gpu=false           # turned off by default.
+    # CoreNeuron relies on passing compiler flags via CMAKE_CXX_FLAGS and CMAKE_C_FLAGS
+    # for architecture-specific optimization. If using OpenACC or trying to coax the
+    # Intel compiler to vectorize, set this variable.
+    ns_cnrn_compiler_flags=-O2
 }
 
 # Attempts to detect harware resouces available on node

--- a/systems/daint-gpu.sh
+++ b/systems/daint-gpu.sh
@@ -44,6 +44,7 @@ ns_threads_per_socket=12
 
 run_with_mpi() {
     export ARB_NUM_THREADS=$ns_threads_per_socket
-    echo srun -n1 -N1 -c $ns_threads_per_socket "${@}"
-    srun -n1 -N1 -c $ns_threads_per_socket "${@}"
+    export OMP_NUM_THREADS=$ns_threads_per_socket
+    echo srun -Cgpu -n$ns_sockets -N1 -c $ns_threads_per_socket "${@}"
+    srun -Cgpu -n$ns_sockets -N1 -c $ns_threads_per_socket "${@}"
 }

--- a/systems/daint-mc.sh
+++ b/systems/daint-mc.sh
@@ -42,6 +42,7 @@ ns_threads_per_socket=36
 
 run_with_mpi() {
     export ARB_NUM_THREADS=$ns_threads_per_socket
-    echo srun -n $ns_sockets -c $ns_threads_per_socket "${@}"
-    srun -n $ns_sockets -c $ns_threads_per_socket "${@}"
+    export OMP_NUM_THREADS=$ns_threads_per_socket
+    echo srun -Cmc -n$ns_sockets -N1 -c$ns_threads_per_socket "${@}"
+    srun -Cmc -n$ns_sockets -N1 -c$ns_threads_per_socket "${@}"
 }

--- a/systems/daint-mc.sh
+++ b/systems/daint-mc.sh
@@ -39,6 +39,7 @@ ns_sockets=2
 ns_threads_per_socket=36
 
 run_with_mpi() {
-    echo ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
-    ARB_NUM_THREADS=$ns_threads_per_socket srun -n $ns_sockets -c $ns_threads_per_socket $*
+    export ARB_NUM_THREADS=$ns_threads_per_socket
+    echo srun -n $ns_sockets -c $ns_threads_per_socket "${@}"
+    srun -n $ns_sockets -c $ns_threads_per_socket "${@}"
 }


### PR DESCRIPTION
Add support in build and runner scripts for target-specific optimizations in CoreNEURON.

* support for user to supply C and C++ compiler flags for CoreNEUORN
* generated runner script passes `-gpu`, `-mpi` and `--cell-permute 2` flags to `coreneuron_exec`  if compiled with GPU and/or MPI support.
* add `scripts/daint-gpu-coreneuron.sh` environment configuration for compiling and running CoreNEURON on Daint.

Performance is really poor, because the input data generated by NEURON is not ideally formatted. It should be one large group of cells, instead of smaller groups. Next steps are to customize how NEURON generates cell groups, but that is more work than we have time for now.

closes #21 

