### PR TITLE
Add simulator tag support.

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -203,13 +203,20 @@ Invocation
 
 .. code-block:: bash
 
-   run-validation.sh [OPTIONS] SIMULATOR [SIMULATOR...]
+   run-validation.sh [OPTIONS] SIMULATOR[:TAG ...] [SIMULATOR...]
 
 ``SIMULATOR`` can be any of the simulators installed with `install-local.sh`.
 By default, `run-validation.sh` will use the current directory as the
 installation and output base directory. If no models are explicitly selected
 with the ``--model`` option (see below), all models and parameter sets will
 be run against each specified simulator.
+
+``SIMULATOR`` can optionally have a sequence of _tags_ appended, which
+are keywords specific to simulator implementations of validation models
+that change the global behaviour of that simulator. For any given simulator,
+the set of supported tags may differ from model to model. See the ``README.md``
+file in each validation model directory for information regarding supported
+tags.
 
 Options are as follows:
 
@@ -243,7 +250,7 @@ of ``%s/%m/%p``. Fields in the ``FORMAT`` string are substituted as follows:
 +--------+---------------------------------------------------------------------+
 | ``%S`` | System name (if defined in system environment script) or host name  |
 +--------+---------------------------------------------------------------------+
-| ``%s`` | Simulator name                                                      |
+| ``%s`` | Simulator name (with tags, if any)                                  |
 +--------+---------------------------------------------------------------------+
 | ``%m`` | Model name                                                          |
 +--------+---------------------------------------------------------------------+

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -43,6 +43,14 @@ The script should run the implementation of the model for the simulator,
 if it exists, with the parameters described in the corresponding parameter
 set file.
 
+The simulator name may have one or more tag suffixes, of the form ``:tag`` —
+these correspond to global flags applied to a simulator to modify its
+behaviour. It is hoped that any supported tags for a simulator have the
+same meaning across different models; ``neuron:firstorder``, for example,
+should be interpreted uniformly as asking NEURON to run with its first
+order solver. This behaviour, however, is not enforced (see the
+implementation notes below).
+
 The exit code determines the status of the test:
 
 +-----------+------------------------+
@@ -94,7 +102,7 @@ Common tools
 
 There is no requirement that validation tests use NetCDF as a format for
 simulator results and reference data, but there are two tools provided
-in ``common/bin``, *viz.* ``comparex`` and ``thresholdx`` that may simplify
+in ``common/bin``, *viz.* ``comparex`` and ``thresholdx``, that may simplify
 the creation of tests that do use NetCDF representations.
 
 The ``comparex`` program compares variables across two different NetCDF
@@ -114,7 +122,8 @@ Implementation notes
 
 The existing run scripts use a helper script ``scripts/model_common.sh``
 to assist in marshalling parameters and invoking particular model
-implementations. For a simulator ``SIM``, they in turn look for an
+implementations; please refer to the comments in this script for
+details. For a simulator ``SIM``, the run scripts then look for an
 implementation-specific script called ``run-SIM``, which expects
 command line arguments of the form:
 
@@ -134,10 +143,11 @@ in current implementations include:
 
 *  Arbor:
 
-   * ``binevents``: bin event delivery times to simulation dt.
+   * ``binevents``: bin event delivery times to simulation dt. Default
+     behaviour is to use precise event times, without any binning.
 
 *  NEURON and CoreNEURON:
 
-   * ``firstorder``: use first order integrator.
-
+   * ``firstorder``: use the first order, fixed time step integrator.
+     Default behaviour is to use the second order fixed time step integrator.
 

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -36,7 +36,7 @@ Model run scripts
 A run script is invoked with the following arguments:
 
 1. The output directory.
-2. The simulator name.
+2. The simulator name (with tags).
 3. The parameter set name.
 
 The script should run the implementation of the model for the simulator,
@@ -53,6 +53,8 @@ The exit code determines the status of the test:
 | 96        | Test failure           |
 +-----------+------------------------+
 | 97        | Missing implementation |
++-----------+------------------------+
+| 98        | Unsupported tag        |
 +-----------+------------------------+
 | other     | Execution error        |
 +-----------+------------------------+
@@ -106,4 +108,36 @@ the form *variable* ``op`` *value* to the data in a NetCDF file, where
 ``op`` is one of ``=``, ``<``, ``>``, ``<=``, ``>=``. It prints the
 predicate and a pass or fail message, and exits with a non-zero value
 if any of the predicates failed.
+
+Implementation notes
+--------------------
+
+The existing run scripts use a helper script ``scripts/model_common.sh``
+to assist in marshalling parameters and invoking particular model
+implementations. For a simulator ``SIM``, they in turn look for an
+implementation-specific script called ``run-SIM``, which expects
+command line arguments of the form:
+
+``run-SIM -o OUTPUT [--tag TAG]... [KEY=VALUE ...]``
+
+The simulator-specific run script is responsible for returning the
+unsupported tag error code if it does not support a requested tag.
+
+A python helper module ``nsuite.stdarg`` is intended to make parsing
+these options more straightforward. Similarly, the C++ header
+``validation/src/include/common_args.h`` is used for the Arbor
+model implementations.
+
+As much as is feasible, it is recommended that model implementations
+for a given simulator support the same set of tags. Tags used
+in current implementations include:
+
+*  Arbor:
+
+   * ``binevents``: bin event delivery times to simulation dt.
+
+*  NEURON and CoreNEURON:
+
+   * ``firstorder``: use first order integrator.
+
 

--- a/scripts/build_validation_models.sh
+++ b/scripts/build_validation_models.sh
@@ -47,7 +47,7 @@ function try_build_project {
     }
 
     msg "$name: building"
-    make install &> build.log || {
+    make VERBOSE=1 install &> build.log || {
         err "$name: build error: refer to log file '$build/build.log'"
         return 1
     }

--- a/scripts/model_common.sh
+++ b/scripts/model_common.sh
@@ -19,8 +19,12 @@ function exit_model_missing { exit 97; }
 # Sets model_name, model_sim and model_param from arguments, provided in
 # this order.
 #
+# If sim has tags, remove them from model_sim, add them to model_tags array.
 # Computes and sets variables model_cache_dir, model_param_data.
 # Creates cache directory if not present.
+#
+# Sets array variable model_impl_stdargs that contains conventional arguments
+# for a model implementation script, viz. --tag TAG ... KEY=VALUE ...
 
 function model_setup {
     if [ -z "$ns_cache_path" ]; then
@@ -32,11 +36,19 @@ function model_setup {
     model_sim="$2"
     model_param="$3"
 
+    IFS=':' read -r -a model_tags <<<"$model_sim"
+    model_sim="${model_tags[0]}"
+    model_tags=("${model_tags[@]:1}")
+
     model_cache_dir="$ns_cache_path/$model_name"
     mkdir -p "$model_cache_dir" || die "$model_name: cannot create directory '$model_cache_dir'"
 
     [ -r "${model_param}.param" ] || die "$model_name: unable to read parameter data '${pset}.param'"
     model_param_data=$(< ${model_param}.param)
+
+    unset model_impl_stdargs
+    for tag in "${model_tags[@]}"; do model_impl_stdargs+=(--tag "$tag"); done
+    for kv in $model_param_data; do model_impl_stdargs+=("$kv"); done
 }
 
 # Print path to file if in CWD, or else relative to cache dir.

--- a/validation/rc-exp2syn-spike/README.md
+++ b/validation/rc-exp2syn-spike/README.md
@@ -47,3 +47,24 @@ Acceptance critera
 The recorded spike times from each cell should differ from the
 reference times by at most 3·_dt_. (This is set explicitly as
 the `max_error` test parameter.)
+
+Implementation notes
+--------------------
+
+Arbor and NEURON implementions save the voltage trace from the
+first, source cell.
+
+### Arbor
+
+Supported tags:
+* `binevents`
+
+  Bin event delivery times to simulation dt.
+
+### NEURON and CoreNEURON
+
+Supported tags:
+* `firstorder`
+
+  Use first order integrator instead of default second order.
+

--- a/validation/rc-exp2syn-spike/generate-rc-exp2syn-spike
+++ b/validation/rc-exp2syn-spike/generate-rc-exp2syn-spike
@@ -27,7 +27,7 @@ tend = 8.
 nsamp = 300
 ts = np.linspace(0., tend, num=nsamp)
 
-output, params = stdarg.parse_run_stdarg()
+output, tags, params = stdarg.parse_run_stdarg()
 param_vars = ['g0', 'mindelay', 'threshold', 'ncell']
 for v in param_vars:
     if v in params: globals()[v] = params[v]

--- a/validation/rc-exp2syn-spike/neuron-rc-exp2syn-spike.py
+++ b/validation/rc-exp2syn-spike/neuron-rc-exp2syn-spike.py
@@ -25,7 +25,7 @@ ncell =     101;    # total number of cells
 
 coreneuron = 0;     # run with coreneuron? 1 => yes
 
-output, params = stdarg.parse_run_stdarg()
+output, tags, params = stdarg.parse_run_stdarg(tagset=['firstorder'])
 param_vars = ['dt', 'g0', 'mindelay', 'threshold', 'ncell', 'coreneuron']
 for v in param_vars:
     if v in params: globals()[v] = params[v]
@@ -121,7 +121,10 @@ for i in range(len(nc_record)):
 
 h.dt = dt
 h.steps_per_ms = 1/dt # or else NEURON might noisily fudge dt
-h.secondorder = 2
+if 'firstorder' in tags:
+    h.secondorder = 0
+else:
+    h.secondorder = 2
 h.tstop = tend
 
 if not coreneuron:

--- a/validation/rc-exp2syn-spike/run
+++ b/validation/rc-exp2syn-spike/run
@@ -29,12 +29,12 @@ impl="./run-$model_sim"
 [ -x "$impl" ] || exit_model_missing
 
 outfile="$outdir/run.nc"
-"$impl" "$outfile" $model_param_data || exit 1
+"$impl" -o "$outfile" ${model_impl_stdargs[@]} || exit $?
 
 # Generate reference data if required.
 
 reffile=$(model_find_cacheable "ref-${model_name}-${model_param}.nc") || \
-    ./generate-rc-exp2syn-spike "$reffile" $model_param_data || exit 1
+    ./generate-rc-exp2syn-spike -o "$reffile" $model_param_data || exit 1
 
 # Run comparison.
 

--- a/validation/rc-expsyn/README.md
+++ b/validation/rc-expsyn/README.md
@@ -33,3 +33,21 @@ Acceptance critera
 The relative error in membrane voltage should be within 1% of
 the reference value at time _t_ = 10 ms.
 
+Implementation notes
+--------------------
+
+### Arbor
+
+Supported tags:
+* `binevents`
+
+  Bin event delivery times to simulation dt.
+
+
+### NEURON
+
+Supported tags:
+* `firstorder`
+
+  Use first order integrator instead of default second order.
+

--- a/validation/rc-expsyn/generate-rc-expsyn
+++ b/validation/rc-expsyn/generate-rc-expsyn
@@ -16,7 +16,7 @@ Erev =   -65;    # reversal potential [mV]
 syntau = 1.0;    # synapse exponential time constant [ms]
 g0 =     0.1;    # synaptic conductance at time zero [µS] 
 
-output, params = stdarg.parse_run_stdarg()
+output, tags, params = stdarg.parse_run_stdarg()
 if 'g0' in params:
     g0 = params['g0']
 

--- a/validation/rc-expsyn/neuron-rc-expsyn.py
+++ b/validation/rc-expsyn/neuron-rc-expsyn.py
@@ -18,7 +18,9 @@ dt = 0.0025
 sample_dt = 0.05
 tend = 10
 
-output, params = stdarg.parse_run_stdarg()
+# One recognized tag: 'firstorder'
+
+output, tags, params = stdarg.parse_run_stdarg(tagset=['firstorder'])
 for v in ['dt', 'g0']:
     if v in params: globals()[v] = params[v]
 
@@ -73,7 +75,10 @@ soma_t.record(h._ref_t, sample_dt)
 
 h.dt = dt
 h.steps_per_ms = 1/dt # or else NEURON might noisily fudge dt
-h.secondorder = 2
+if 'firstorder' in tags:
+    h.secondorder = 0
+else:
+    h.secondorder = 2
 h.tstop = tend
 h.run()
 

--- a/validation/rc-expsyn/run
+++ b/validation/rc-expsyn/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Invocation: run outputdir simname paramsetname
+# Invocation:
+#    run outputdir simname paramsetname
+#    run --list-tags simname
 
 # Change to script directory and attempt to find nsuite base directory.
 
@@ -16,18 +18,18 @@ shift
 source "$ns_base_path/scripts/model_common.sh"
 model_setup rc-expsyn "$@"
 
-# Run sim-specific implementation with parameter data.
+# Run sim-specific implementation with tags and parameter data.
 
 impl="./run-$model_sim"
 [ -x "$impl" ] || exit_model_missing
 
 outfile="$outdir/run.nc"
-"$impl" "$outfile" $model_param_data || exit 1
+"$impl" -o "$outfile" ${model_impl_stdargs[@]} || exit $?
 
 # Generate reference data if required.
 
 reffile=$(model_find_cacheable "ref-${model_name}-${model_param}.nc") || \
-    ./generate-rc-expsyn "$reffile" $model_param_data || exit 1
+    ./generate-rc-expsyn -o "$reffile" $model_param_data || exit 1
 
 # Run comparison.
 

--- a/validation/src/arbor-rc-exp2syn-spike/CMakeLists.txt
+++ b/validation/src/arbor-rc-exp2syn-spike/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(netcdf REQUIRED)
 
 add_executable(arbor-rc-exp2syn-spike arbor-rc-exp2syn-spike.cpp)
 target_link_libraries(arbor-rc-exp2syn-spike arbor::arbor netcdf::netcdf)
+target_include_directories(arbor-rc-exp2syn-spike PRIVATE ${CMAKE_SOURCE_DIR}/../include)
 
 install(TARGETS arbor-rc-exp2syn-spike DESTINATION bin)
 

--- a/validation/src/arbor-rc-expsyn/CMakeLists.txt
+++ b/validation/src/arbor-rc-expsyn/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(netcdf REQUIRED)
 
 add_executable(arbor-rc-expsyn arbor-rc-expsyn.cpp)
 target_link_libraries(arbor-rc-expsyn arbor::arbor netcdf::netcdf)
+target_include_directories(arbor-rc-expsyn PRIVATE ${CMAKE_SOURCE_DIR}/../include)
 
 install(TARGETS arbor-rc-expsyn DESTINATION bin)
 

--- a/validation/src/include/common_args.h
+++ b/validation/src/include/common_args.h
@@ -1,0 +1,92 @@
+#pragma once
+
+// Common handling of command line arguments in validation test implementations.
+//
+// Argument convention is:
+//     test-impl -o <output> [-t <tag> [-t <tag>] ... ] [key=value ...]
+//     test-impl --list-tags
+//
+// Unrecognized options are left in argv for parsing by the implementation.
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+using paramset = std::unordered_map<std::string, double>;
+using tagset = std::unordered_set<std::string>;
+
+struct common_args {
+    std::string output;
+    tagset tags;
+    paramset params;
+};
+
+constexpr int unrecognized_tag_exit_code = 98;
+
+inline void parse_common_args(common_args& A, int argc, char** argv, const tagset& valid_tags) {
+    const char* prog = strrchr(argv[0], '/');
+    prog = prog? prog+1: argv[0];
+
+    auto shift = [](char** a, int n=1) {
+        char** b = a;
+        for (int i = 0; *b && i<n; ++i) ++b;
+
+        while (*a) {
+            *a++ = *b;
+            if (*b) ++b;
+        }
+    };
+
+    auto usage = [prog](int exit_code = 0) {
+        (exit_code? std::cerr: std::cout) <<
+            "usage: " << prog << " -o <output> [-t <tag>]... [key=value ...]\n"
+            "       " << prog << " --list-tags\n"
+            "       " << prog << " --help\n";
+        std::exit(exit_code);
+    };
+
+    for (char** arg = argv+1; *arg;) {
+        if (!strcmp(*arg, "--list-tags")) {
+            for (auto& tag: valid_tags) std::cout << tag << "\n";
+            std::exit(0);
+        }
+
+        if (!strcmp(*arg, "--help")) {
+            usage();
+        }
+
+        if (!strcmp(*arg, "-o")) {
+            shift(arg);
+            if (!*arg) usage(1);
+            A.output = *arg;
+            shift(arg);
+            continue;
+        }
+
+        if (!strcmp(*arg, "--tag")) {
+            shift(arg);
+            if (!*arg) usage(1);
+            if (!valid_tags.count(*arg)) usage(unrecognized_tag_exit_code);
+            A.tags.insert(*arg);
+            shift(arg);
+            continue;
+        }
+
+        if (auto eq = strchr(*arg, '=')) {
+            try {
+                A.params[std::string(*arg, eq)] = std::stod(eq+1);
+                shift(arg);
+                continue;
+            }
+            catch (std::logic_error&) {
+                usage(true);
+            }
+        }
+
+        ++arg;
+    }
+
+    if (A.output.empty()) usage(1);
+}

--- a/validation/src/include/netcdf_wrap.h
+++ b/validation/src/include/netcdf_wrap.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// Exception and macro for wrapping netcdf calls, throwing on error.
+
+#include <stdexcept>
+#include <string>
+
+#include <netcdf.h>
+
+struct nc_error: std::runtime_error {
+    nc_error(const char* fn, int st):
+        std::runtime_error(std::string(fn)+": "+std::string(nc_strerror(st))),
+        call(fn),
+        status(st) {}
+
+    int status;
+    std::string call;
+};
+
+#define nc_check(fn, ...)\
+if (auto r = fn(__VA_ARGS__)) { throw nc_error(#fn, r); } else {}
+


### PR DESCRIPTION
Implements issue #54.

* Support augmenting simulator names with ':tag' suffixes for configuring simulator behaviour in validation tests.
* Split out common support code in Arbor validation model implementations (command line argument handling; netcdf exception wrapper).
* Add new exit code representing failure for a model implementation to understand a requested tag.
* Make command line arguments in model implementations clearer (output given by '-o', tags by '--tag' etc.)
* Extend model_common.sh to help with simulator tag handling.
* Add tag 'binevents' for existing Arbor models, 'firstorder' for NEURON models.
* Update documentation to suit.