### PR TITLE
Feature to build arbor's modcc seperately

### DIFF
--- a/scripts/build_arbor.sh
+++ b/scripts/build_arbor.sh
@@ -1,6 +1,6 @@
 arb_repo_path=$ns_build_path/arbor
 arb_build_path=$arb_repo_path/build
-modcc_build_path=$arb_repo_path/build.modcc
+modcc_build_path=$arb_repo_path/build_modcc
 arb_checked_flag="${arb_repo_path}/checked_out"
 
 # clear log file from previous builds
@@ -32,13 +32,13 @@ fi
 mkdir -p "$arb_build_path"
 
 # build modcc
-if [ "$ns_arb_modcc" == "ON" ]; then
+if [ "$ns_arb_xcompile_modcc" == "ON" ]; then
     mkdir -p "$modcc_build_path"
 
     # build external modcc
     msg "ARBOR: build modcc"
     cd "$modcc_build_path"
-    cmake .. -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ >> "$out" 2>&1
+    cmake .. -DARB_ARCH=native >> "$out" 2>&1
     make -j $ns_makej modcc >> "$out" 2>&1
     cd ..
 fi
@@ -50,7 +50,7 @@ cmake_args="$cmake_args -DARB_WITH_MPI=$ns_with_mpi"
 cmake_args="$cmake_args -DARB_WITH_GPU=$ns_arb_with_gpu"
 cmake_args="$cmake_args -DARB_ARCH=$ns_arb_arch"
 cmake_args="$cmake_args -DARB_VECTORIZE=$ns_arb_vectorize"
-if [ "$ns_arb_modcc" == "ON" ]; then
+if [ "$ns_arb_xcompile_modcc" == "ON" ]; then
     cmake_args="$cmake_args -DARB_MODCC=${modcc_build_path}/bin/modcc"
 fi
 
@@ -90,7 +90,7 @@ do
     cd "$build_path"
 
     msg "ARBOR: cmake"
-    if [ "$ns_arb_modcc" == "ON" ]; then
+    if [ "$ns_arb_xcompile_modcc" == "ON" ]; then
         cmake "$source_path" -DARB_MODCC=${modcc_build_path}/bin/modcc -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX:PATH="$ns_install_path" >> "$out" 2>&1
     else
         cmake "$source_path" -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX:PATH="$ns_install_path" >> "$out" 2>&1

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -72,6 +72,7 @@ default_environment() {
     ns_arb_arch=native
     ns_arb_with_gpu=OFF
     ns_arb_vectorize=ON
+    ns_arb_xcompile_modcc=OFF
 
     # Neuron specific
 


### PR DESCRIPTION
Adds option `ns_arb_xcompile_modcc(=ON/OFF)` to `scripts/build_arbor.sh`. Defaults to OFF in `scripts/environment.sh` unless overriden in system configuration scripts.  