### PR TITLE
Standard attributes in validation output

### DIFF
--- a/common/bin/tsplotx
+++ b/common/bin/tsplotx
@@ -92,7 +92,7 @@ def take(n, s):
 
 class TimeSeries:
     def __init__(self, ts, ys, **kwargs):
-        self.t = np.array(ts)
+        self.t = np.array(ts, dtype=np.double)
         n = self.t.shape[0]
 
         self.y = np.full_like(self.t, np.nan)
@@ -247,15 +247,32 @@ class PlotData:
         return self.group_key_label
 
     def unique_labels(self, formatter=lambda x: x):
-        # attempt to create unique labels for plots in the group based on
-        # meta data
+        # attempt to create unique labels for plots in the group based on meta data
         labels = [s.label() for s in self.series]
         if len(labels)<2:
             return labels
 
         n = len(labels)
         keyset = reduce(lambda k, s: k.union(s.meta.keys()), self.series, set())
-        keyi = iter(keyset)
+
+        # pick keys based on a heuristic scoring:
+        # -- prefer keys with short but non-empty values in each series
+        # -- prefer keys which differ across more series.
+
+        key_score = {}
+        for k in keyset:
+            vs = {s.meta.get(k, None) for s in self.series}
+            if len(vs)==1:
+                continue
+
+            score = sum((1-1/vlen for v in vs if v is not None for vlen in [len(v)] if vlen>0))
+            score += len(vs)-1
+            key_score[k] = score
+
+        ranked_keylist = [k for k in key_score]
+        ranked_keylist.sort(key=lambda k: -key_score[k])
+
+        keyi = iter(ranked_keylist)
         try:
             while len(set(labels)) != n:
                 k = next(keyi)

--- a/common/python/nsuite/stdattr.py
+++ b/common/python/nsuite/stdattr.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Common attribute conventions for NetCDF/xarray output from python
+# validation scripts.
+
+from functools import reduce
+
+def set_stdattr(outx, model=None, simulator=None, simulator_build=None, tags=[], params={}):
+    for (k, v) in params.items():
+        outx.attrs[str(k)] = float(v)
+
+    tags.sort()
+    if simulator is not None:
+        outx.attrs['simulator'] = reduce(lambda s, tag: s+':'+tag, tags, str(simulator))
+        if simulator_build is not None:
+            outx.attrs['simulator_build'] = str(simulator_build)
+
+    if model is not None:
+        outx.attrs['validation_model'] = str(model)
+

--- a/validation/rc-expsyn/generate-rc-expsyn
+++ b/validation/rc-expsyn/generate-rc-expsyn
@@ -9,6 +9,7 @@ import re
 import sys
 
 import nsuite.stdarg as stdarg
+import nsuite.stdattr as stdattr
 
 rm =     100;    # total membrane resistance [MΩ]
 cm =    0.01;    # total membrane capacitance [nF]
@@ -51,6 +52,9 @@ ts = np.linspace(0., tend, num=nsamp)
 result = integrate.solve_ivp(dv_dt, (0., tend), [Erev], method='LSODA', t_eval=ts, jac=jacobian, atol=1e-10/nsamp, rtol=1e-10/nsamp)
 
 out = xarray.Dataset({'voltage': (['time'], result.y[0])}, coords={'time': ts})
-out['g0'] = g0
+out.voltage.attrs['units'] = 'mV'
+out.time.attrs['units'] = 'ms'
+
+stdattr.set_stdattr(out, model='rc-expsyn', simulator='reference', tags=tags, params=params)
 out.to_netcdf(output)
 

--- a/validation/rc-expsyn/neuron-rc-expsyn.py
+++ b/validation/rc-expsyn/neuron-rc-expsyn.py
@@ -6,6 +6,7 @@ import os
 
 from neuron import h
 import nsuite.stdarg as stdarg
+import nsuite.stdattr as stdattr
 import xarray
 
 rm =     100;    # total membrane resistance [MΩ]
@@ -85,7 +86,10 @@ h.run()
 # Collect and save data
 
 out = xarray.Dataset({'voltage': (['time'], list(soma_v))}, coords={'time': list(soma_t)})
-out['g0'] = g0
-out['dt'] = dt
+out.voltage.attrs['units'] = 'mV'
+out.time.attrs['units'] = 'ms'
+
+nrnver = h.nrnversion()
+stdattr.set_stdattr(out, model='rc-expsyn', simulator='neuron', simulator_build=nrnver, tags=tags, params=params)
 out.to_netcdf(output)
 

--- a/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
+++ b/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
@@ -11,8 +11,10 @@
 #include <arbor/sampling.hpp>
 #include <arbor/simple_sampler.hpp>
 #include <arbor/simulation.hpp>
+#include <arbor/version.hpp>
 
 #include "common_args.h"
+#include "common_attr.h"
 #include "netcdf_wrap.h"
 
 using namespace arb;
@@ -189,20 +191,25 @@ int main(int argc, char** argv) {
     nc_check(nc_def_var, ncid, "spike", NC_DOUBLE, 1, &gid_dimid, &spike_id);
     nc_check(nc_def_var, ncid, "delay", NC_DOUBLE, 1, &gid_dimid, &delay_id);
 
-    std::vector<int> scalar_ids;
-    for (const auto& kv: A.params) {
-        int id;
-        nc_check(nc_def_var, ncid, kv.first.c_str(), NC_DOUBLE, 0, nullptr, &id);
-        scalar_ids.push_back(id);
-    }
+    auto nc_put_att_cstr = [](int ncid, int varid, const char* name, const char* value) {
+        nc_check(nc_put_att_text, ncid, varid, name, std::strlen(value), value);
+    };
+
+    nc_put_att_cstr(ncid, time_id, "units", "ms");
+    nc_put_att_cstr(ncid, spike_id, "units", "ms");
+    nc_put_att_cstr(ncid, delay_id, "units", "ms");
+    nc_put_att_cstr(ncid, v0_id, "units", "mV");
+
+    common_attr attrs;
+    attrs.model = "rc-exp2syn-spike";
+    attrs.simulator = "arbor";
+    attrs.simulator_build = arb::version;
+    attrs.simulator_build += ' ';
+    attrs.simulator_build += arb::source_id;
+
+    set_common_attr(ncid, attrs, A.tags, A.params);
 
     nc_check(nc_enddef, ncid);
-
-    unsigned pidx = 0;
-    for (const auto& kv: A.params) {
-        int id;
-        nc_check(nc_put_var_double, ncid, scalar_ids[pidx++], &kv.second);
-    }
 
     std::vector<double> time, voltage;
     time.reserve(tlen);

--- a/validation/src/include/common_attr.h
+++ b/validation/src/include/common_attr.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <netcdf.h>
+
+#include "common_args.h"
+#include "netcdf_wrap.h"
+
+struct common_attr {
+    std::string model, simulator, simulator_build;
+};
+
+void set_common_attr(int ncid, const common_attr& attrs, const tagset& tags, const paramset& params) {
+    if (!attrs.model.empty()) {
+        nc_check(nc_put_att_text, ncid, NC_GLOBAL, "validation_model", attrs.model.size(), attrs.model.c_str());
+    }
+    if (!attrs.simulator_build.empty()) {
+        nc_check(nc_put_att_text, ncid, NC_GLOBAL, "simulator_build", attrs.simulator_build.size(), attrs.simulator_build.c_str());
+    }
+
+    if (!attrs.simulator.empty()) {
+        std::string simtagged = attrs.simulator;
+
+        std::vector<std::string> taglist(tags.begin(), tags.end());
+        std::sort(taglist.begin(), taglist.end());
+        for (auto& t: taglist) {
+            simtagged += ':';
+            simtagged += t;
+        }
+
+        nc_check(nc_put_att_text, ncid, NC_GLOBAL, "simulator", simtagged.size(), simtagged.c_str());
+    }
+
+    for (auto& kv: params) {
+        nc_check(nc_put_att_double, ncid, NC_GLOBAL, kv.first.c_str(), NC_DOUBLE, 1u, &kv.second);
+    }
+}
+


### PR DESCRIPTION
* New python fn for standard application to netcdf output of validation model attributes.
* New C++ header for helping standard attribute writing too.
* Use new attribute convention for existing validation models.
* Improve tsplotx guess for disambiguating labels
* Force tsplotx to regard its timeseries data as floating point.

Implements #74 