### PR TITLE
Update Arbor to v0.2.2

### DIFF
--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -70,6 +70,12 @@ public:
         return params_.cell.synapses;
     }
 
+    arb::util::any get_global_properties(cell_kind kind) const override {
+        arb::cable_cell_global_properties prop;
+        prop.default_parameters = arb::neuron_parameter_defaults;
+        return prop;
+    }
+
     // Each cell has one incoming connection, from cell with gid-1,
     // and fan_in-1 random connections with very low weight.
     std::vector<arb::cell_connection> connections_on(cell_gid_type gid) const override {
@@ -332,9 +338,10 @@ double interp(const std::array<T,2>& r, unsigned i, unsigned n) {
 arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& params) {
     arb::cable_cell cell;
 
+    cell.default_parameters.axial_resistivity = 100;
+
     // Add soma.
     auto soma = cell.add_soma(12.6157/2.0); // For area of 500 μm².
-    soma->rL = 100;
     soma->add_mechanism("hh");
 
     std::vector<std::vector<unsigned>> levels;
@@ -363,7 +370,6 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
                     auto dend = cell.add_cable(sec, arb::section_kind::dendrite, dend_radius, dend_radius, l);
                     dend->set_compartments(nc);
                     dend->add_mechanism("pas");
-                    dend->rL = 100;
                 }
             }
         }

--- a/scripts/build_arbor.sh
+++ b/scripts/build_arbor.sh
@@ -22,6 +22,7 @@ if [ ! -f "$arb_checked_flag" ]; then
         git checkout "$ns_arb_branch" >> "$out" 2>&1
         [ $? != 0 ] && exit_on_error "see ${out}"
     fi
+
     touch "${arb_checked_flag}"
 else
     msg "ARBOR: repository has already downloaded"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -67,7 +67,7 @@ default_environment() {
     # Arbor specific
 
     ns_arb_git_repo=https://github.com/arbor-sim/arbor.git
-    ns_arb_branch=v0.2
+    ns_arb_branch=v0.2.2
 
     ns_arb_arch=native
     ns_arb_with_gpu=OFF

--- a/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
+++ b/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
@@ -76,11 +76,15 @@ struct rc_exp2syn_spike_recipe: public arb::recipe {
     cell_kind get_cell_kind(cell_gid_type) const override { return cell_kind::cable; }
 
     util::any get_global_properties(cell_kind kind) const override {
-        if (kind!=cell_kind::cable) return util::any{};
+        arb::cable_cell_global_properties prop;
+        prop.default_parameters.init_membrane_potential = erev;
+        prop.ion_species.clear();
 
-        cable_cell_global_properties props;
-        props.init_membrane_potential_mV = erev;
-        return props;
+        // Relevant parameters will be set on the cell itself.
+        prop.default_parameters.axial_resistivity = 0;
+        prop.default_parameters.membrane_capacitance = 0;
+        prop.default_parameters.temperature_K = 0;
+        return prop;
     }
 
     probe_info get_probe(cell_member_type id) const override {
@@ -106,7 +110,7 @@ struct rc_exp2syn_spike_recipe: public arb::recipe {
         pas["e"] = erev;
 
         auto soma = c.add_soma(r*1e6);
-        soma->cm = cm*1e-9/area;       // [F/m^2]
+        soma->parameters.membrane_capacitance = cm*1e-9/area; // [F/m^2]
         soma->add_mechanism(pas);
 
         mechanism_desc expsyn("exp2syn");

--- a/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
+++ b/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
@@ -50,12 +50,16 @@ struct rc_expsyn_recipe: public arb::recipe {
     cell_size_type num_probes(cell_gid_type) const override { return 1; }
     cell_kind get_cell_kind(cell_gid_type) const override { return cell_kind::cable; }
 
-    util::any get_global_properties(cell_kind kind) const override {
-        if (kind!=cell_kind::cable) return util::any{};
+    arb::util::any get_global_properties(cell_kind kind) const override {
+        arb::cable_cell_global_properties prop;
+        prop.default_parameters.init_membrane_potential = erev;
+        prop.ion_species.clear();
 
-        cable_cell_global_properties props;
-        props.init_membrane_potential_mV = erev;
-        return props;
+        // Relevant parameters will be set on the cell itself.
+        prop.default_parameters.axial_resistivity = 0;
+        prop.default_parameters.membrane_capacitance = 0;
+        prop.default_parameters.temperature_K = 0;
+        return prop;
     }
 
     probe_info get_probe(cell_member_type id) const override {
@@ -79,7 +83,7 @@ struct rc_expsyn_recipe: public arb::recipe {
         pas["e"] = erev;
 
         auto soma = c.add_soma(r*1e6);
-        soma->cm = cm*1e-9/area;       // [F/m^2]
+        soma->parameters.membrane_capacitance = cm*1e-9/area; // [F/m^2]
         soma->add_mechanism(pas);
 
         mechanism_desc expsyn("expsyn");


### PR DESCRIPTION
 Migrate bench/tests to Arbor 0.2.2

* Adjust Arbor sources to use new cable cell API.
* Bump Arbor tag to 0.2.2