### PR TITLE
update arbor models to new morphology (v0.2.2)

### DIFF
--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -130,7 +130,7 @@ public:
         // Get the appropriate kind for measuring voltage.
         cell_probe_address::probe_kind kind = cell_probe_address::membrane_voltage;
         // Measure at the soma.
-        arb::segment_location loc(0, 0.0);
+        arb::mlocation loc{0, 0.0};
 
         return arb::probe_info{id, kind, cell_probe_address{loc, kind}};
     }

--- a/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
+++ b/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
@@ -49,8 +49,8 @@ struct rc_exp2syn_spike_recipe: public arb::recipe {
     // Computed values:
     std::vector<double> delay;               // delay[i] is connection delay from gid 0 to gid i
 
-    static segment_location soma_centre() {
-        return segment_location(0u, 0.5);
+    static mlocation soma_centre() {
+        return mlocation{0u, 0.5};
     }
 
     explicit rc_exp2syn_spike_recipe(const paramset& ps):

--- a/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
+++ b/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
@@ -39,8 +39,8 @@ struct rc_expsyn_recipe: public arb::recipe {
     // Customizable parameters:
     double g0;                               // synaptic conductance at time 0 [µS]
 
-    static segment_location soma_centre() {
-        return segment_location(0u, 0.5);
+    static mlocation soma_centre() {
+        return mlocation{0u, 0.5};
     }
 
     explicit rc_expsyn_recipe(const paramset& ps): g0(ps.at("g0")) {}


### PR DESCRIPTION
Changed `segment_location()` to `mlocation{}` in ring benchmark and validation cases.

Fixes #87, #82