### PR TITLE
Update for dryrun with busyring

### DIFF
--- a/benchmarks/engines/busyring/arbor/parameters.hpp
+++ b/benchmarks/engines/busyring/arbor/parameters.hpp
@@ -30,11 +30,13 @@ struct ring_params {
 
     std::string name = "default";
     unsigned num_cells = 10;
+    unsigned num_ranks = 1;
     unsigned ring_size = 10;
     double min_delay = 10;
     double duration = 100;
     double dt = 0.025;
     bool record_voltage = false;
+    bool dryrun = true;
     std::string odir = ".";
     cell_parameters cell;
 };
@@ -69,11 +71,13 @@ ring_params read_options(int argc, char** argv) {
 
     param_from_json(params.name, "name", json);
     param_from_json(params.num_cells, "num-cells", json);
+    param_from_json(params.num_ranks, "num-ranks", json);
     param_from_json(params.ring_size, "ring-size", json);
     param_from_json(params.duration, "duration", json);
     param_from_json(params.dt, "dt", json);
     param_from_json(params.min_delay, "min-delay", json);
     param_from_json(params.record_voltage, "record", json);
+    param_from_json(params.dryrun, "dryrun", json);
     param_from_json(params.cell.max_depth, "depth", json);
     param_from_json(params.cell.branch_probs, "branch-probs", json);
     param_from_json(params.cell.compartments, "compartments", json);

--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -318,7 +318,7 @@ int main(int argc, char** argv) {
         }
 
         auto profile = arb::profile::profiler_summary();
-        std::cout << profile << "\n";
+        if (root) std::cout << profile << "\n";
 
         auto report = arb::profile::make_meter_report(meters, context);
         if (root) std::cout << report;

--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -229,6 +229,7 @@ int main(int argc, char** argv) {
 
 #ifdef ARB_PROFILE_ENABLED
         arb::profile::profiler_initialize(context);
+        std::cout << "Profiling enabled" << std::endl;
 #endif
 
         // Print a banner with information about hardware configuration
@@ -315,6 +316,9 @@ int main(int argc, char** argv) {
             std::string fname = params.odir + "/" + params.name + "_voltages.json";
             write_trace_json(fname, voltage);
         }
+
+        auto profile = arb::profile::profiler_summary();
+        std::cout << profile << "\n";
 
         auto report = arb::profile::make_meter_report(meters, context);
         if (root) std::cout << report;

--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -229,7 +229,7 @@ int main(int argc, char** argv) {
 
 #ifdef ARB_PROFILE_ENABLED
         arb::profile::profiler_initialize(context);
-        std::cout << "Profiling enabled" << std::endl;
+        if (root) std::cout << "Profiling enabled" << std::endl;
 #endif
 
         // Print a banner with information about hardware configuration

--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -136,7 +136,7 @@ public:
         // Get the appropriate kind for measuring voltage.
         cell_probe_address::probe_kind kind = cell_probe_address::membrane_voltage;
         // Measure at the soma.
-        arb::segment_location loc(0, 0.0);
+        arb::mlocation loc{0, 0.0};
 
         return arb::probe_info{id, kind, cell_probe_address{loc, kind}};
     }

--- a/install-local.sh
+++ b/install-local.sh
@@ -146,6 +146,7 @@ msg "arch:            $ns_arb_arch"
 msg "gpu:             $ns_arb_with_gpu"
 msg "vectorize:       $ns_arb_vectorize"
 msg "profiling:       $ns_arb_with_profiling"
+msg "prefetch size:   $ns_arb_prefetch_size"
 echo
 msghi "---- NEURON ----"
 msg "tarball:         $ns_nrn_tarball"

--- a/install-local.sh
+++ b/install-local.sh
@@ -146,6 +146,7 @@ msg "arch:            $ns_arb_arch"
 msg "gpu:             $ns_arb_with_gpu"
 msg "vectorize:       $ns_arb_vectorize"
 msg "profiling:       $ns_arb_with_profiling"
+msg "cmake:           $ns_arb_cmake_args"
 echo
 msghi "---- NEURON ----"
 msg "tarball:         $ns_nrn_tarball"

--- a/install-local.sh
+++ b/install-local.sh
@@ -145,6 +145,7 @@ msg "branch:          $ns_arb_branch"
 msg "arch:            $ns_arb_arch"
 msg "gpu:             $ns_arb_with_gpu"
 msg "vectorize:       $ns_arb_vectorize"
+msg "profiling:       $ns_arb_with_profiling"
 echo
 msghi "---- NEURON ----"
 msg "tarball:         $ns_nrn_tarball"

--- a/install-local.sh
+++ b/install-local.sh
@@ -119,6 +119,13 @@ if [ "$ns_environment" != "" ]; then
     echo
 fi
 
+msghi "---- Configuration ----"
+msg "ns_makej:              $ns_makej"
+msg "ns_threads_per_core:   $ns_threads_per_core"
+msg "ns_cores_per_socket:   $ns_cores_per_socket"
+msg "ns_sockets:            $ns_sockets"
+msg "ns_threads_per_socket: $ns_threads_per_socket"
+echo
 msghi "---- TARGETS ----"
 msg "build arbor:       $ns_build_arbor"
 msg "build neuron:      $ns_build_neuron"

--- a/install-local.sh
+++ b/install-local.sh
@@ -146,7 +146,6 @@ msg "arch:            $ns_arb_arch"
 msg "gpu:             $ns_arb_with_gpu"
 msg "vectorize:       $ns_arb_vectorize"
 msg "profiling:       $ns_arb_with_profiling"
-msg "prefetch size:   $ns_arb_prefetch_size"
 echo
 msghi "---- NEURON ----"
 msg "tarball:         $ns_nrn_tarball"

--- a/scripts/build_arbor.sh
+++ b/scripts/build_arbor.sh
@@ -52,6 +52,7 @@ cmake_args="$cmake_args -DARB_WITH_GPU=$ns_arb_with_gpu"
 cmake_args="$cmake_args -DARB_ARCH=$ns_arb_arch"
 cmake_args="$cmake_args -DARB_VECTORIZE=$ns_arb_vectorize"
 cmake_args="$cmake_args -DARB_WITH_PROFILING=$ns_arb_with_profiling"
+cmake_args="$cmake_args -DARB_PREFETCH_SIZE=$ns_arb_prefetch_size"
 if [ "$ns_arb_xcompile_modcc" == "ON" ]; then
     cmake_args="$cmake_args -DARB_MODCC=${modcc_build_path}/bin/modcc"
 fi

--- a/scripts/build_arbor.sh
+++ b/scripts/build_arbor.sh
@@ -52,7 +52,6 @@ cmake_args="$cmake_args -DARB_WITH_GPU=$ns_arb_with_gpu"
 cmake_args="$cmake_args -DARB_ARCH=$ns_arb_arch"
 cmake_args="$cmake_args -DARB_VECTORIZE=$ns_arb_vectorize"
 cmake_args="$cmake_args -DARB_WITH_PROFILING=$ns_arb_with_profiling"
-cmake_args="$cmake_args -DARB_PREFETCH_SIZE=$ns_arb_prefetch_size"
 if [ "$ns_arb_xcompile_modcc" == "ON" ]; then
     cmake_args="$cmake_args -DARB_MODCC=${modcc_build_path}/bin/modcc"
 fi

--- a/scripts/build_arbor.sh
+++ b/scripts/build_arbor.sh
@@ -51,6 +51,7 @@ cmake_args="$cmake_args -DARB_WITH_MPI=$ns_with_mpi"
 cmake_args="$cmake_args -DARB_WITH_GPU=$ns_arb_with_gpu"
 cmake_args="$cmake_args -DARB_ARCH=$ns_arb_arch"
 cmake_args="$cmake_args -DARB_VECTORIZE=$ns_arb_vectorize"
+cmake_args="$cmake_args -DARB_WITH_PROFILING=$ns_arb_with_profiling"
 if [ "$ns_arb_xcompile_modcc" == "ON" ]; then
     cmake_args="$cmake_args -DARB_MODCC=${modcc_build_path}/bin/modcc"
 fi

--- a/scripts/build_arbor.sh
+++ b/scripts/build_arbor.sh
@@ -56,6 +56,7 @@ if [ "$ns_arb_xcompile_modcc" == "ON" ]; then
     cmake_args="$cmake_args -DARB_MODCC=${modcc_build_path}/bin/modcc"
 fi
 
+cmake_args="$cmake_args $ns_arb_cmake_args"
 msg "ARBOR: cmake $cmake_args"
 cmake "$arb_repo_path" $cmake_args >> "$out" 2>&1
 [ $? != 0 ] && exit_on_error "see ${out}"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -67,7 +67,7 @@ default_environment() {
     # Arbor specific
 
     ns_arb_git_repo=https://github.com/arbor-sim/arbor.git
-    ns_arb_branch=v0.2.2
+    ns_arb_branch=master
 
     ns_arb_arch=native
     ns_arb_with_gpu=OFF

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -74,6 +74,7 @@ default_environment() {
     ns_arb_vectorize=ON
     ns_arb_xcompile_modcc=OFF
     ns_arb_with_profiling=OFF
+    ns_arb_prefetch_size=1024
 
     # Neuron specific
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -73,6 +73,7 @@ default_environment() {
     ns_arb_with_gpu=OFF
     ns_arb_vectorize=ON
     ns_arb_xcompile_modcc=OFF
+    ns_arb_with_profiling=OFF
 
     # Neuron specific
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -74,7 +74,6 @@ default_environment() {
     ns_arb_vectorize=ON
     ns_arb_xcompile_modcc=OFF
     ns_arb_with_profiling=OFF
-    ns_arb_prefetch_size=1024
 
     # Neuron specific
 

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -1,3 +1,5 @@
+export LANG=C
+
 init_tcol() {
     # Set global associative array 'tcol' with entries for the eight
     # commonly supported colours plus entries for other highlight modes.

--- a/systems/base.sh
+++ b/systems/base.sh
@@ -18,10 +18,10 @@ ns_cc=$(which mpicc)
 ns_cxx=$(which mpicxx)
 ns_with_mpi=ON
 
-ns_arb_arch=skylake-avx512
+ns_arb_arch=native #skylake-avx512
 ns_arb_branch=master
 
-ns_makej=20
+ns_makej=4
 
 ### benchmark execution options ###
 ns_threads_per_core=2

--- a/systems/base.sh
+++ b/systems/base.sh
@@ -1,5 +1,26 @@
 ### environment ###
 
+.util/field-max() {
+    local n=$1; shift
+    lscpu --parse=$n | grep -v '#' | sort -t, -r | head -1
+}
+
+.util/logical-cores-per-socket() {
+    echo $(($(.util/field-max cpu)+1))
+}
+
+.util/cores-per-socket() {
+    echo $(($(.util/field-max core)+1))
+}
+
+.util/sockets() {
+    echo $(($(.util/field-max socket)+1))
+}
+
+.util/threads-per-core() {
+    echo $(($(.util/logical-cores-per-socket) / $(.util/cores-per-socket)))
+}
+
 # record system name
 ns_sysname="base"
 
@@ -18,16 +39,16 @@ ns_cc=$(which mpicc)
 ns_cxx=$(which mpicxx)
 ns_with_mpi=ON
 
-ns_arb_arch=native #skylake-avx512
+ns_arb_arch=native
 ns_arb_branch=master
 
-ns_makej=4
+ns_makej=$(($(.util/sockets)*$(.util/logical-cores-per-socket)))
 
 ### benchmark execution options ###
-ns_threads_per_core=2
-ns_cores_per_socket=20
-ns_sockets=2
-ns_threads_per_socket=40
+ns_threads_per_core=$(.util/threads-per-core)
+ns_cores_per_socket=$(.util/cores-per-socket)
+ns_sockets=$(.util/sockets)
+ns_threads_per_socket=$((ns_cores_per_socket*ns_threads_per_core))
 
 # activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
 run_with_mpi() {

--- a/systems/base.sh
+++ b/systems/base.sh
@@ -2,7 +2,7 @@
 
 .util/field-max() {
     local n=$1; shift
-    lscpu --parse=$n | grep -v '#' | sort -t, -r | head -1
+    lscpu --parse=$n | grep -v '#' | sort -n -r | head -1
 }
 
 .util/logical-cores-per-socket() {

--- a/systems/base.sh
+++ b/systems/base.sh
@@ -1,0 +1,38 @@
+### environment ###
+
+# record system name
+ns_sysname="base"
+
+# set up environment for building on the multicore part of juwels
+ns_python=$(which python3)
+
+# for (core)neuron
+#module load mpi4py/3.0.1-Python-3.6.8
+#module load flex/2.6.4
+
+# for validation tests
+#module load netCDF/4.6.3-serial
+
+### compilation options ###
+ns_cc=$(which mpicc)
+ns_cxx=$(which mpicxx)
+ns_with_mpi=ON
+
+ns_arb_arch=skylake-avx512
+ns_arb_branch=master
+
+ns_makej=20
+
+### benchmark execution options ###
+ns_threads_per_core=2
+ns_cores_per_socket=20
+ns_sockets=2
+ns_threads_per_socket=40
+
+# activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
+run_with_mpi() {
+    export ARB_NUM_THREADS=$ns_threads_per_socket
+    export OMP_NUM_THREADS=$ns_threads_per_socket
+    echo srun -n$ns_sockets -N1 -c$ns_threads_per_socket "${@}"
+    mpirun -n$ns_sockets -N1 -c$ns_threads_per_socket "${@}"
+}

--- a/systems/juwels-mc.sh
+++ b/systems/juwels-mc.sh
@@ -31,13 +31,13 @@ ns_with_mpi=ON
 ns_arb_arch=skylake-avx512
 ns_arb_branch=master
 
-ns_makej=20
+ns_makej=24
 
 ### benchmark execution options ###
 ns_threads_per_core=2
-ns_cores_per_socket=20
+ns_cores_per_socket=24
 ns_sockets=2
-ns_threads_per_socket=40
+ns_threads_per_socket=48
 
 # activate budget via jutil env activate -p <cproject> -A <budget> before running the benchmark
 run_with_mpi() {

--- a/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
+++ b/validation/src/arbor-rc-exp2syn-spike/arbor-rc-exp2syn-spike.cpp
@@ -49,8 +49,8 @@ struct rc_exp2syn_spike_recipe: public arb::recipe {
     // Computed values:
     std::vector<double> delay;               // delay[i] is connection delay from gid 0 to gid i
 
-    static segment_location soma_centre() {
-        return segment_location(0u, 0.5);
+    static mlocation soma_centre() {
+        return mlocation{0u, 0.5};
     }
 
     explicit rc_exp2syn_spike_recipe(const paramset& ps):

--- a/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
+++ b/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
@@ -39,8 +39,8 @@ struct rc_expsyn_recipe: public arb::recipe {
     // Customizable parameters:
     double g0;                               // synaptic conductance at time 0 [µS]
 
-    static segment_location soma_centre() {
-        return segment_location(0u, 0.5);
+    static mlocation soma_centre() {
+        return mlocation{0u, 0.5};
     }
 
     explicit rc_expsyn_recipe(const paramset& ps): g0(ps.at("g0")) {}
@@ -76,20 +76,26 @@ struct rc_expsyn_recipe: public arb::recipe {
     }
 
     util::unique_any get_cell_description(cell_gid_type) const override {
-        cable_cell c;
+        sample_tree samples;
+        samples.append({{0, 0, 0, r*1e6}, 1});
 
         mechanism_desc pas("pas");
         pas["g"] = 1e-10/(rm*area);    // [S/cm^2]
         pas["e"] = erev;
 
-        auto soma = c.add_soma(r*1e6);
-        soma->parameters.membrane_capacitance = cm*1e-9/area; // [F/m^2]
-        soma->add_mechanism(pas);
-
         mechanism_desc expsyn("expsyn");
         expsyn["tau"] = syntau;
         expsyn["e"] = 0;
-        c.add_synapse(soma_centre(), expsyn);
+
+        label_dict labels;
+        labels.set("soma", reg::tagged(1));
+        labels.set("centre", soma_centre());
+
+        cable_cell c(morphology(samples), labels);
+        c.default_parameters.membrane_capacitance = cm*1e-9/area; // [F/m^2]
+
+        c.paint("soma", pas);
+        c.place("centre", expsyn);
 
         return c;
     }

--- a/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
+++ b/validation/src/arbor-rc-expsyn/arbor-rc-expsyn.cpp
@@ -39,8 +39,8 @@ struct rc_expsyn_recipe: public arb::recipe {
     // Customizable parameters:
     double g0;                               // synaptic conductance at time 0 [µS]
 
-    static segment_location soma_centre() {
-        return segment_location(0u, 0.5);
+    static mlocation soma_centre() {
+        return mlocation{0u, 0.5};
     }
 
     explicit rc_expsyn_recipe(const paramset& ps): g0(ps.at("g0")) {}


### PR DESCRIPTION
topic: features/dryrun ring

Results of testing #899 in arbor.
* Dry run is added to busyring.
* Thus, context needs to be default constructible
* Output configuration information (sockets, cores, etc)
* Set up base configuration for testing on regular machines
* Revert the revert on the updat for segment_location -> mlocation
