### PR TITLE
Miscellaneous tiny fixes.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -180,7 +180,7 @@ There are Arbor-specific options for checking out Arbor from a Git repository, a
 Variable                  Default value                                 Explanation
 ========================  ===========================================   ======================================================
 ``ns_arb_git_repo``       ``https://github.com/arbor-sim/arbor.git``    URL or directory for the Git repository to check out Arbor source from.
-``ns_arb_branch``         ``v0.2``                                      The branch/tag/SHA to check out. Master will be used if empty.
+``ns_arb_branch``         ``v0.4``                                      The branch/tag/SHA to check out. Master will be used if empty.
 ``ns_arb_arch``           ``native``                                    `The CPU architecture target <https://arbor.readthedocs.io/en/latest/install.html#architecture>`_
                                                                         for Arbor. Must be set when cross compiling.
                                                                         Default ``native`` targets the architecture used to configure NSuite.

--- a/install-local.sh
+++ b/install-local.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 usage() {
     cat <<'_end_'
 Usage: install-local.sh [--pyvenv=VENVOPT] [--env=SCRIPT] [--prefix=PATH] TARGET [TARGET...]

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 usage() {
     cat <<_end_
 Usage: run-bench.sh [OPTIONS] SIMULATOR


### PR DESCRIPTION
* Update install docs to indicate that default Arbor branch is 0.4.
* And #! lines for install-local and run-bench so that they can be executed directly.