### PR TITLE
Update for Arbor v0.5

### DIFF
--- a/benchmarks/engines/busyring/arbor/ring.cpp
+++ b/benchmarks/engines/busyring/arbor/ring.cpp
@@ -516,7 +516,7 @@ arb::cable_cell branch_cell(arb::cell_gid_type gid, const cell_parameters& param
     // Add spike threshold detector at the soma.
     decor.place(arb::mlocation{0,0}, arb::threshold_detector{10});
 
-    // Add a synapse to the mid point of the first dendrite.
+    // Add a synapse to proximal end of first dendrite.
     decor.place(arb::mlocation{1, 0}, "expsyn");
 
     // Add additional synapses that will not be connected to anything.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -180,7 +180,7 @@ There are Arbor-specific options for checking out Arbor from a Git repository, a
 Variable                  Default value                                 Explanation
 ========================  ===========================================   ======================================================
 ``ns_arb_git_repo``       ``https://github.com/arbor-sim/arbor.git``    URL or directory for the Git repository to check out Arbor source from.
-``ns_arb_branch``         ``v0.2``                                      The branch/tag/SHA to check out. Master will be used if empty.
+``ns_arb_branch``         ``v0.5``                                      The branch/tag/SHA to check out. Master will be used if empty.
 ``ns_arb_arch``           ``native``                                    `The CPU architecture target <https://arbor.readthedocs.io/en/latest/install.html#architecture>`_
                                                                         for Arbor. Must be set when cross compiling.
                                                                         Default ``native`` targets the architecture used to configure NSuite.

--- a/install-local.sh
+++ b/install-local.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 usage() {
     cat <<'_end_'
 Usage: install-local.sh [--pyvenv=VENVOPT] [--env=SCRIPT] [--prefix=PATH] TARGET [TARGET...]
@@ -64,11 +66,11 @@ do
             ;;
         --pyvenv=* )
             ns_pyvenv=${1#--pyvenv=}
-	    ;;
+            ;;
         --pyvenv )
-	    shift
+            shift
             ns_pyvenv=$1
-	    ;;
+            ;;
         --env=* )
             ns_environment=${1#--env=}
             ;;
@@ -175,18 +177,18 @@ if [ "$ns_pyvenv" != disable ]; then
     msghi "Initializing python virtual environment"
     ns_pyvenv_opt=
     if [ "$ns_pyvenv" == inherit ]; then
-	ns_pyvenv_opt=--system-site-packages
+        ns_pyvenv_opt=--system-site-packages
     fi
 
     msg "Installing python modules: $ns_pyvenv_modules"
     (
-	exec >> "$ns_build_path/log_pyvenv" 2>&1
-	if "$ns_python" -m venv $ns_pyvenv_opt "$ns_pyvenv_path"; then
-	    source "$ns_pyvenv_path/bin/activate"
-	    for pkg in $ns_pyvenv_modules; do
-	        pip install "$pkg"
-	    done
-	fi
+        exec >> "$ns_build_path/log_pyvenv" 2>&1
+        if "$ns_python" -m venv $ns_pyvenv_opt "$ns_pyvenv_path"; then
+            source "$ns_pyvenv_path/bin/activate"
+            for pkg in $ns_pyvenv_modules; do
+                pip install "$pkg"
+            done
+        fi
     )
 fi
 

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 usage() {
     cat <<_end_
 Usage: run-bench.sh [OPTIONS] SIMULATOR

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -67,7 +67,7 @@ default_environment() {
     # Arbor specific
 
     ns_arb_git_repo=https://github.com/arbor-sim/arbor.git
-    ns_arb_branch=v0.4
+    ns_arb_branch=v0.5
 
     ns_arb_arch=native
     ns_arb_gpu=none
@@ -175,7 +175,7 @@ save_environment() {
     pyvenv_activate=$ns_pyvenv_path/bin/activate
     source_pyvenv_script=
     if [ -r "$pyvenv_activate" ]; then
-	source_pyvenv_script="source '$pyvenv_activate'"
+        source_pyvenv_script="source '$pyvenv_activate'"
     fi
 
     cat <<_end_ > "$ns_config_path/env_$sim.sh"

--- a/validation/src/arbor-cable-steadystate/arbor-cable-steadystate.cpp
+++ b/validation/src/arbor-cable-steadystate/arbor-cable-steadystate.cpp
@@ -78,17 +78,16 @@ struct rc_cable_recipe: public arb::recipe {
         segment_tree tree;
         tree.append(arb::mnpos, {0., 0., 0., d0/2}, {0., 0., length, d1/2}, 0);
 
-        cable_cell c(arb::morphology(tree), {});
-
-        c.default_parameters.discretization = cv_policy_fixed_per_branch(n);
-
         mechanism_desc pas("pas");
         pas["g"] = 1e-4/rm; // [S/cm^2]
         pas["e"] = 0; // erev=0
 
-        c.paint(reg::all(), pas);
-        c.place(mlocation{0, 1.}, i_clamp{0, INFINITY, iinj});
-        return c;
+        decor D;
+        D.paint(reg::all(), pas);
+        D.place(mlocation{0, 1.}, i_clamp{0, INFINITY, iinj});
+        D.set_default(cv_policy_fixed_per_branch(n));
+
+        return cable_cell(tree, {}, D);
     }
 
     // time constant in [ms]

--- a/validation/src/arbor-rallpack1/arbor-rallpack1.cpp
+++ b/validation/src/arbor-rallpack1/arbor-rallpack1.cpp
@@ -71,7 +71,7 @@ struct rc_rallpack1_recipe: public arb::recipe {
         for (unsigned i = 0; i < num_probes(gid); ++i) {
           arb::mlocation loc{0, i==0? x0: x1};
           probes.push_back(cable_probe_membrane_voltage{loc});
-        } 
+        }
         return probes; 
     }
 
@@ -79,17 +79,16 @@ struct rc_rallpack1_recipe: public arb::recipe {
         segment_tree tree;
         tree.append(arb::mnpos, {0., 0., 0., d/2}, {0., 0., length, d/2}, 0);
 
-        cable_cell c(arb::morphology(tree), {});
-
-        c.default_parameters.discretization = cv_policy_fixed_per_branch(n);
-
         mechanism_desc pas("pas");
         pas["g"] = 1e-4/rm; // [S/cm^2]
         pas["e"] = (double)erev;
 
-        c.paint(reg::all(), pas);
-        c.place(mlocation{0, 0}, i_clamp{0, INFINITY, iinj});
-        return c;
+        decor D;
+        D.paint(reg::all(), pas);
+        D.place(mlocation{0, 0}, i_clamp{0, INFINITY, iinj});
+        D.set_default(cv_policy_fixed_per_branch(n));
+
+        return cable_cell(tree, {}, D);
     }
 };
 


### PR DESCRIPTION
* Modify validation sources for 0.5 decor API.
* Replace some tabs with eight spaces in scripts.
* Update Arbor branch for download, and in install docs.
* Minor comment fix in ring benchmark.
* Add #! for install-local.sh and run-bench.sh